### PR TITLE
Add `Remotes` for Bioconductor packages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,4 +51,6 @@ VignetteBuilder: knitr
 Remotes: 
     erblast/easyalluvial,
     erblast/parcats,
-    rstudio/gt
+    rstudio/gt,
+    bioc::3.10/RTCGA,
+    bioc::3.10/RTCGA.clinical


### PR DESCRIPTION
This fixes the installation issue describes in #42. To automatically install packages from Bioconductor the `Remotes` field in `DESCRIPTION` has to be filled.