### PR TITLE
Fix/issue58

### DIFF
--- a/R/vr_alluvial_wrangling.R
+++ b/R/vr_alluvial_wrangling.R
@@ -87,7 +87,7 @@ vr_alluvial_wrangling <- function(
   linenames_summary_long <-
     data_with_no_tx %>%
     dplyr::group_by(linenumber, linename) %>%
-    dplyr:: summarise(patient_count = n()) %>%
+    dplyr:: summarise(patient_count = dplyr::n()) %>%
     dplyr::arrange(linenumber, desc(patient_count)) %>%
     dplyr::mutate(freq = patient_count / sum(patient_count))
 
@@ -97,7 +97,7 @@ vr_alluvial_wrangling <- function(
   linenames_summary <-
     alluvial_plot_data %>%
     dplyr::group_by(linenumber, linename) %>%
-    dplyr:: summarise(patient_count = n()) %>%
+    dplyr:: summarise(patient_count = dplyr::n()) %>%
     dplyr::arrange(linenumber, desc(patient_count)) %>%
     dplyr::mutate(freq = patient_count / sum(patient_count))
 
@@ -151,7 +151,7 @@ vr_mostcommon_linenames <- function(data, n_common){
   mostcommon <- data %>%
     dplyr::group_by(linename, linenumber) %>%
     dplyr::summarise(
-      n = n()
+      n = dplyr::n()
     ) %>%
     dplyr::ungroup() %>%
     dplyr::group_by(linenumber) %>%

--- a/R/vr_create_tableone.R
+++ b/R/vr_create_tableone.R
@@ -52,10 +52,10 @@ vr_create_tableone <- function(data, groupCols = NULL, overall=TRUE, summary_fun
   }
   
   data <- data %>% 
-    dplyr::group_by(!!!syms(groupCols))
+    dplyr::group_by(!!!dplyr::syms(groupCols))
   
   data_ns <- data %>% 
-    dplyr::summarise(summary = n()) %>% 
+    dplyr::summarise(summary = dplyr::n()) %>% 
     tidyr::pivot_wider(names_from = tidyselect::any_of(groupCols), values_from = "summary") %>%
     dplyr::mutate(variable = "Sample", summary_id = "N")
   

--- a/R/vr_utils.R
+++ b/R/vr_utils.R
@@ -27,13 +27,13 @@ vr_summarize.factor <- function(x){
 #' @export
 vr_summarize.numeric <- function(x){
   dat <- list(
-    mean = mean(x, na.rm = T),
-    min = min(x, na.rm = T),
-    Q1 = quantile(x, probs=0.25),
-    median = median(x, na.rm = T) ,
-    Q3 = quantile(x, probs=0.75),
-    max = max(x, na.rm = T),
-    sd = sd(x, na.rm = T)
+    mean = mean(x, na.rm = TRUE),
+    min = min(x, na.rm = TRUE),
+    Q1 = quantile(x, probs=0.25, na.rm = TRUE),
+    median = median(x, na.rm = TRUE),
+    Q3 = quantile(x, probs=0.75, na.rm = TRUE),
+    max = max(x, na.rm = TRUE),
+    sd = sd(x, na.rm = TRUE)
   )
   list(dat)
 }
@@ -81,10 +81,10 @@ vr_summarize_tab1.factor <- function(x){
 #' @export
 vr_summarize_tab1.numeric <- function(x){
   dat <- list(
-    `Mean (SD)` = paste0(format(mean(x, na.rm = T), digits = 3), " (", format(sd(x, na.rm = T), digits = 3), ")"),
-    `Median (IQR)` = paste0(format(median(x, na.rm = T)), " (", format(quantile(x, probs=0.25)),
-                            "-", format(quantile(x, probs=0.75)), ")"),
-    `Min-max` = paste0(format(min(x, na.rm = T)), "-", format(max(x, na.rm = T))),
+    `Mean (SD)` = paste0(format(mean(x, na.rm = TRUE), digits = 3), " (", format(sd(x, na.rm = TRUE), digits = 3), ")"),
+    `Median (IQR)` = paste0(format(median(x, na.rm = TRUE)), " (", format(quantile(x, probs=0.25, na.rm = TRUE)),
+                            "-", format(quantile(x, probs=0.75, na.rm = TRUE)), ")"),
+    `Min-max` = paste0(format(min(x, na.rm = TRUE)), "-", format(max(x, na.rm = TRUE))),
     Missing = paste0(format(sum(is.na(x))), " (", format(100 * sum(is.na(x))/dplyr::n(), trim=TRUE), "%)")
   )
   list(dat)

--- a/R/vr_utils.R
+++ b/R/vr_utils.R
@@ -13,7 +13,7 @@ vr_summarize.factor <- function(x){
 
   dat <- tibble::enframe(x1) %>%
     dplyr::group_by(value) %>%
-    dplyr::summarise(N = n()) %>%
+    dplyr::summarise(N = dplyr::n()) %>%
     dplyr::mutate(`%` = round(100 * N/sum(N), 3)) %>%
     tidyr::pivot_wider(names_from = value, values_from = c("N", "%"), names_sep=" ") %>%
     as.list()
@@ -66,7 +66,7 @@ vr_summarize_tab1.factor <- function(x){
 
   dat <- tibble::enframe(x1) %>%
     dplyr::group_by(value) %>%
-    dplyr::summarise(N = n()) %>%
+    dplyr::summarise(N = dplyr::n()) %>%
     dplyr::mutate(`n (%)` = paste0(N, " (", format(100 * N/sum(N), digits = 3, trim=TRUE), "%)")) %>%
     dplyr::select(-N) %>%
     tidyr::pivot_wider(names_from = value, values_from = c("n (%)"), names_sep=" ") %>%
@@ -85,7 +85,7 @@ vr_summarize_tab1.numeric <- function(x){
     `Median (IQR)` = paste0(format(median(x, na.rm = T)), " (", format(quantile(x, probs=0.25)),
                             "-", format(quantile(x, probs=0.75)), ")"),
     `Min-max` = paste0(format(min(x, na.rm = T)), "-", format(max(x, na.rm = T))),
-    Missing = paste0(format(sum(is.na(x))), " (", format(100 * sum(is.na(x))/n(), trim=TRUE), "%)")
+    Missing = paste0(format(sum(is.na(x))), " (", format(100 * sum(is.na(x))/dplyr::n(), trim=TRUE), "%)")
   )
   list(dat)
 }
@@ -98,7 +98,7 @@ vr_summarize_tab1.numeric <- function(x){
 vr_summarize_tab1.default <- function(x){
   dat <- list(
     `Unique values` = format(length(unique(x))),
-    `Missing (%)` = paste0(format(sum(is.na(x))), " (", format(100 * sum(is.na(x))/n(), trim=TRUE), "%)")
+    `Missing (%)` = paste0(format(sum(is.na(x))), " (", format(100 * sum(is.na(x))/dplyr::n(), trim=TRUE), "%)")
   )
   list(dat)
 }


### PR DESCRIPTION
This addresses two small issue with the `vr_create_tableone` function:

- Some `dplyr` functions (e.g. `n()`, `syms()`) did not have the necessary prefix causing errors if you only loaded the `visR` package
- The quantile function used to calculate the IQR would throw an error if missing values were present.