### PR TITLE
Rbest remove from depends 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,6 @@ Imports:
     ggplot2,
     patchwork,
     tibble,
-    RBesT,
     DOT,
     tidyr,
     dplyr,

--- a/R/vr_plt_forest.R
+++ b/R/vr_plt_forest.R
@@ -1,24 +1,31 @@
 #' Render a simple forest plot given a tibble
-#'
+#' This is an experimental function that may be developed over time. 
+#' 
+#' @description
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("experimental")}
+
 #' @param td tidied tibble
 #'
 #' @return ggplot object
 #' @export
 #'
 #' @examples
-#' library(RBesT)
-#' library(dplyr)
-#' library(ggplot2)
+#' \donttest{
+#' # Commenting out to not depend on RBest - issue with cran availability
+#' # library(RBesT)
+#' # library(dplyr)
+#' # library(ggplot2)
 #'
-#' example(crohn)
-#' vr_tidy_rbest(map_crohn)
-#' map_crohn %>% vr_tidy_rbest() %>% filter(model == "meta") %>%
-#' vr_plt_forest()
+#' # example(crohn)
+#' # vr_tidy_rbest(map_crohn)
+#' # map_crohn %>% vr_tidy_rbest() %>% filter(model == "meta") %>%
+#' # vr_plt_forest()
 #'
-#' map_crohn %>% vr_tidy_rbest() %>% filter(model == "stratified") %>%
-#' vr_plt_forest()
+#' # map_crohn %>% vr_tidy_rbest() %>% filter(model == "stratified") %>%
+#' # vr_plt_forest()
 #'
-#' map_crohn %>% vr_tidy_rbest() %>% vr_plt_forest() + facet_wrap(~ model)
+#' # map_crohn %>% vr_tidy_rbest() %>% vr_plt_forest() + facet_wrap(~ model)
+#' }
 #'
 vr_plt_forest <- function(td){
   gg <-

--- a/R/vr_tidy_rbest.R
+++ b/R/vr_tidy_rbest.R
@@ -1,4 +1,9 @@
 #' Returns a tidied RBesT gMAP object
+#' 
+#' This is an experimental function that may be developed over time. 
+#' 
+#' @description
+#' \Sexpr[results=rd, stage=render]{lifecycle::badge("experimental")}
 #'
 #' @param x RBesT gMAP object
 #' @param prob probability range for uncertainty interval
@@ -11,12 +16,14 @@
 #' @export
 #'
 #' @examples
+#' \donttest{
 #' library(RBesT)
 #' example(crohn)
 #' vr_tidy_rbest(map_crohn)
 #'
 #' map_crohn %>%
 #' vr_tidy_rbest()
+#' }
 #'
 vr_tidy_rbest <- function(x, prob = 0.95){
 

--- a/R/vr_tidy_rbest.R
+++ b/R/vr_tidy_rbest.R
@@ -17,12 +17,13 @@
 #'
 #' @examples
 #' \donttest{
-#' library(RBesT)
-#' example(crohn)
-#' vr_tidy_rbest(map_crohn)
+#' # Commenting out to not depend on RBest - issue with cran availability
+#' # library(RBesT)
+#' # example(crohn)
+#' # vr_tidy_rbest(map_crohn)
 #'
-#' map_crohn %>%
-#' vr_tidy_rbest()
+#' # map_crohn %>%
+#' # vr_tidy_rbest()
 #' }
 #'
 vr_tidy_rbest <- function(x, prob = 0.95){

--- a/man/vr_plt_forest.Rd
+++ b/man/vr_plt_forest.Rd
@@ -2,7 +2,8 @@
 % Please edit documentation in R/vr_plt_forest.R
 \name{vr_plt_forest}
 \alias{vr_plt_forest}
-\title{Render a simple forest plot given a tibble}
+\title{Render a simple forest plot given a tibble
+This is an experimental function that may be developed over time.}
 \usage{
 vr_plt_forest(td)
 }
@@ -13,21 +14,24 @@ vr_plt_forest(td)
 ggplot object
 }
 \description{
-Render a simple forest plot given a tibble
+\Sexpr[results=rd, stage=render]{lifecycle::badge("experimental")}
 }
 \examples{
-library(RBesT)
-library(dplyr)
-library(ggplot2)
+\donttest{
+# Commenting out to not depend on RBest - issue with cran availability
+# library(RBesT)
+# library(dplyr)
+# library(ggplot2)
 
-example(crohn)
-vr_tidy_rbest(map_crohn)
-map_crohn \%>\% vr_tidy_rbest() \%>\% filter(model == "meta") \%>\%
-vr_plt_forest()
+# example(crohn)
+# vr_tidy_rbest(map_crohn)
+# map_crohn \%>\% vr_tidy_rbest() \%>\% filter(model == "meta") \%>\%
+# vr_plt_forest()
 
-map_crohn \%>\% vr_tidy_rbest() \%>\% filter(model == "stratified") \%>\%
-vr_plt_forest()
+# map_crohn \%>\% vr_tidy_rbest() \%>\% filter(model == "stratified") \%>\%
+# vr_plt_forest()
 
-map_crohn \%>\% vr_tidy_rbest() \%>\% vr_plt_forest() + facet_wrap(~ model)
+# map_crohn \%>\% vr_tidy_rbest() \%>\% vr_plt_forest() + facet_wrap(~ model)
+}
 
 }

--- a/man/vr_tidy_rbest.Rd
+++ b/man/vr_tidy_rbest.Rd
@@ -22,12 +22,13 @@ This is an experimental function that may be developed over time.
 }
 \examples{
 \donttest{
-library(RBesT)
-example(crohn)
-vr_tidy_rbest(map_crohn)
+# Commenting out to not depend on RBest - issue with cran availability
+# library(RBesT)
+# example(crohn)
+# vr_tidy_rbest(map_crohn)
 
-map_crohn \%>\%
-vr_tidy_rbest()
+# map_crohn \%>\%
+# vr_tidy_rbest()
 }
 
 }

--- a/man/vr_tidy_rbest.Rd
+++ b/man/vr_tidy_rbest.Rd
@@ -15,14 +15,19 @@ vr_tidy_rbest(x, prob = 0.95)
 td tidied tibble
 }
 \description{
-Returns a tidied RBesT gMAP object
+\Sexpr[results=rd, stage=render]{lifecycle::badge("experimental")}
+}
+\details{
+This is an experimental function that may be developed over time.
 }
 \examples{
+\donttest{
 library(RBesT)
 example(crohn)
 vr_tidy_rbest(map_crohn)
 
 map_crohn \%>\%
 vr_tidy_rbest()
+}
 
 }


### PR DESCRIPTION
This is an experimental function and needs to be developed. At the moment this dependency is causing errors in the visR package. This has been removed and the tidy rbest function moved to indicate it is experimental. 