### PR TITLE
Fixed issue #97. Attrition table not calculated properly

### DIFF
--- a/R/vr_attrition_table.R
+++ b/R/vr_attrition_table.R
@@ -73,8 +73,11 @@ vr_attrition_table <- function(
 
    for (each_cond in criteria_map$criteria_conditions) {
 
-      final_cond          <- ifelse(is.null(final_cond), each_cond,
-                                    paste(final_cond, each_cond, sep=" & "))
+      final_cond          <- ifelse(is.null(final_cond), 
+                                    each_cond,
+                                    paste(final_cond, paste0(paste0("(", each_cond), ")"), sep=" & "))
+                                       
+      print(final_cond)
       person_count_temp   <- data %>%
          dplyr::filter(eval(parse(text=final_cond))) %>%
          dplyr::select(!!subject_column_name) %>% n_distinct

--- a/R/vr_attrition_table.R
+++ b/R/vr_attrition_table.R
@@ -77,7 +77,6 @@ vr_attrition_table <- function(
                                     each_cond,
                                     paste(final_cond, paste0(paste0("(", each_cond), ")"), sep=" & "))
                                        
-      print(final_cond)
       person_count_temp   <- data %>%
          dplyr::filter(eval(parse(text=final_cond))) %>%
          dplyr::select(!!subject_column_name) %>% n_distinct


### PR DESCRIPTION
 due to an error in operator precedence. Specifically, conditions where added to a string in the form "c1 & c2" but single conditions were not put into brackets. In a condition included another binary operator, e.g. c1 = a1 | a2, then the string would be a1 | a2 & c2. Now it should correctly be (a1 | a2) & c2.

Fixes https://github.com/openpharma/visR/issues/97