### PR TITLE
Fixed bugs in risktable algorithm for graph

### DIFF
--- a/R/add_risktable.R
+++ b/R/add_risktable.R
@@ -83,9 +83,6 @@ add_risktable.ggsurvfit <- function(
   
   survfit_object <- eval(gg$data$call[[1]])
   
-#text <- eval(expr=paste0("survival::", call[1], "(formula = ", call[2], ", data = ", call[3], ")"))
-#survfit_object <- eval(parse(text=text))
-  
   ggbld <- ggplot2::ggplot_build(gg)
   
   if (is.null(breaks)) breaks <- as.numeric(ggbld$layout$panel_params[[1]]$x$get_labels())
@@ -112,15 +109,17 @@ add_risktable.ggsurvfit <- function(
 
 
   tbls <-  base::Map(function(statlist, title = NA) {
-    ggrisk <- ggplot2::ggplot(final, ggplot2::aes(x = time,
-                                         y = stats::reorder(y_values, dplyr::desc(y_values)),
-                                             label = format(get(statlist), nsmall = 0) # = value columns
-                                         )
-                              ) +
+    ggrisk <- ggplot2::ggplot(final,
+                              ggplot2::aes(
+                                 x = time,
+                                 y = stats::reorder(y_values, dplyr::desc(y_values)),
+                                 label = format(get(statlist), nsmall = 0) # = value columns
+                              )
+                            ) +
       ggplot2::geom_text(size = 3.0, hjust=.5, vjust=.5, angle=0, show.legend = F) +
       ggplot2::theme_bw() +
       ggplot2::scale_x_continuous(breaks = times,
-                                  limits = c(min(time_ticks), max(time_ticks))) +
+                                  limits = c(min(breaks), max(breaks))) +
       ggplot2::theme(axis.title.x = ggplot2::element_text(size = 8,
                                                  vjust = 1,
                                                  hjust = 1),

--- a/R/visR.R
+++ b/R/visR.R
@@ -1,4 +1,0 @@
-## usethis namespace: start
-#' @importFrom tibble tibble
-## usethis namespace: end
-NULL


### PR DESCRIPTION
1) alignment of risktable with graph by using breaks of graph instead of times from risktable

2) Ensured correct titles are used for each risk table

3) ensured we see the minimum at risk when it falls between pre-defined breaks => take next available break

4) Removed visR.R as we dont need this