### PR TITLE
Changed the way the x- and y-axis labels are applied

### DIFF
--- a/R/visr.R
+++ b/R/visr.R
@@ -235,11 +235,42 @@ visr.survfit <- function(
 
 # Obtain X-asis label ----------------------------------------------------------
 
-  if (is.null(x_label)){
-    if ("PARAM" %in% names(x)) x_label = x[["PARAM"]]
-    if (! "PARAM" %in% names(x)) x_label = "time"
-    if (!is.null(x_units)) x_label = paste0(x_label, " (", x_units, ")")
+  if (base::is.null(x_label)){
+    
+    if ("PARAM" %in% base::names(x)) {
+      
+      if (base::length(base::unique(x[["PARAM"]])) == 1) { 
+        
+        x_label <- as.character(x[["PARAM"]][[1]])
+        
+      } else {
+        
+        base::warning("More than one unique entry in 'PARAM'.")
+        
+      }
+      
+    } else if ("PARAMCD" %in% base::names(x)) {
+      
+      if (base::length(base::unique(x[["PARAMCD"]])) == 1) { 
+        
+        x_label <- as.character(x[["PARAMCD"]][[1]])
+        
+      } else {
+        
+        base::warning("More than one unique entry in 'PARAMCD'.")
+        
+      }
+      
+    } else {
+      
+      base::warning("The x-axis label was not specified and could also not be automatically determined due to absence of 'PARAM' and 'PARAMCD'.")
+      
+    }
+    
+    if (!is.null(x_units)) { x_label = paste0(x_label, " (", x_units, ")") }
+    
   }
+  
   if (is.null(x_ticks)) x_ticks = pretty(x$time, 10)
 
 # Obtain Y-asis label ----------------------------------------------------------

--- a/R/visr.R
+++ b/R/visr.R
@@ -268,13 +268,13 @@ visr.survfit <- function(
 
   gg <- ggplot2::ggplot(tidy_object, ggplot2::aes(x = time, group = strata)) +
     ggplot2::geom_step(ggplot2::aes(y = est, col = strata)) + 
-    ggplot2::scale_x_continuous(name = x_label,
-                                breaks = x_ticks,
+    ggplot2::scale_x_continuous(breaks = x_ticks,
                                 limits = c(min(x_ticks), max(x_ticks))) +
-    ggplot2::scale_y_continuous(name = y_label,
-                                breaks = y_ticks,
+    ggplot2::xlab(x_label) +
+    ggplot2::scale_y_continuous(breaks = y_ticks,
                                 labels = yscaleFUN,
                                 limits = c(min(y_ticks), max(y_ticks))) +
+    ggplot2::ylab(y_label) +
     ggplot2::theme(legend.position = legend_position) +
     NULL
   

--- a/R/visr.R
+++ b/R/visr.R
@@ -269,6 +269,10 @@ visr.survfit <- function(
     
     if (!is.null(x_units)) { x_label = paste0(x_label, " (", x_units, ")") }
     
+  } else {
+    
+    if (!is.null(x_units)) { x_label = paste0(x_label, " (", x_units, ")") }
+    
   }
   
   if (is.null(x_ticks)) x_ticks = pretty(x$time, 10)

--- a/tests/testthat/test-visr_plot.R
+++ b/tests/testthat/test-visr_plot.R
@@ -4,7 +4,7 @@
 #' @section Last update date:
 #' 27-MAY-2021
 
-# Specifications ----------------------------------------------------------
+# Specifications ---------------------------------------------------------------
 
 #' T1. visR::visr() only accepts `survfit` or `attrition`.
 #' T1.1 No error when applied to a `survfit` object.
@@ -26,13 +26,14 @@
 #' T2.13 When `x_label` is `NULL` and the `survfit` object does not have a `PARAM` but a `PARAMCD` column, the `x_label` is set to `PARAMCD`.
 #' T2.14 When `x_label` is `NULL` and the `survfit` object does have a `PARAM` but no `PARAMCD` column, the `x_label` is set to `PARAM`.
 #' T2.15 When `x_label` is `NULL` and the `survfit` object does not have a `PARAM` or `PARAMCD` column, the `x_label` is `NULL`.
-#' T2.16 An error when `y_label` is not `NULL`, a `character` string or an `expression`.
-#' T2.17 An error when `x_units` is not `NULL` or a `character` string.
-#' T2.18 An error when `x_ticks` is not `NULL` or a `numeric`.
-#' T2.19 An error when `y_ticks` is not `NULL` or a `numeric`.
-#' T2.20 No error when a valid option is passed to `legend_position`.
-#' T2.21 An error when the string is not amongst the valid options for `legend_position`.
-#' T2.22 An error when an undefined option is passed to `legend_position`.
+#' T2.16 When `x_label` and `x_unit` are both defined, they are concatenated into the final `x_label`.
+#' T2.17 An error when `y_label` is not `NULL`, a `character` string or an `expression`.
+#' T2.18 An error when `x_units` is not `NULL` or a `character` string.
+#' T2.19 An error when `x_ticks` is not `NULL` or a `numeric`.
+#' T2.20 An error when `y_ticks` is not `NULL` or a `numeric`.
+#' T2.21 No error when a valid option is passed to `legend_position`.
+#' T2.22 An error when the string is not amongst the valid options for `legend_position`.
+#' T2.23 An error when an undefined option is passed to `legend_position`.
 #' T3. The y-axis properties are correctly deducted from the provided `fun` when applying `visR::visr()` to a `survfit` object.
 #' T3.1 No error when `y_label` is `NULL` and `fun` is one of the valid string options.
 #' T3.2 An error when `y_label` is `NULL`, `fun` is a string but not one of the valid options.
@@ -61,8 +62,7 @@
 #' T4.18 An error when `border` is a `character` string but not a valid colour.
 #' T4.19 An error when `border` is not a `character` string.
 
-
-# Requirement T1 ----------------------------------------------------------
+# Requirement T1 ---------------------------------------------------------------
 
 testthat::context("visr_plot - T1. visR::visr() only accepts `survfit` or `attrition`.")
 
@@ -109,7 +109,7 @@ testthat::test_that("T1.3 An error when applied to an object that is not `survfi
   
 })
 
-# Requirement T2 ----------------------------------------------------------
+# Requirement T2 ---------------------------------------------------------------
 
 testthat::context("visr_plot - T2. Invalid parameters are captured when applying `visR::visr()` to a `survfit` object and respective warnings/errors are thrown.")
 
@@ -287,7 +287,18 @@ testthat::test_that("T2.15 When `x_label` is `NULL` and the `survfit` object doe
   
 })
 
-testthat::test_that("T2.16 An error when `y_label` is not `NULL`, a `character` string or an `expression`.", {
+testthat::test_that("T2.16 When `x_label` and `x_unit` are both defined, they are concatenated into the final `x_label`.", {
+  
+  survfit_object <- adtte %>%
+    visR::estimate_KM("SEX") 
+  
+  gg <- survfit_object %>% visR::visr(x_label = "visR", x_unit = "Rsiv")
+  
+  testthat::expect_equal(gg$labels$x, "visR (Rsiv)")
+  
+})
+
+testthat::test_that("T2.17 An error when `y_label` is not `NULL`, a `character` string or an `expression`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -300,7 +311,7 @@ testthat::test_that("T2.16 An error when `y_label` is not `NULL`, a `character` 
   
 })
 
-testthat::test_that("T2.17 An error when `x_units` is not `NULL` or a `character` string.", {
+testthat::test_that("T2.18 An error when `x_units` is not `NULL` or a `character` string.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -313,7 +324,7 @@ testthat::test_that("T2.17 An error when `x_units` is not `NULL` or a `character
   
 })
 
-testthat::test_that("T2.18 An error when `x_ticks` is not `NULL` or a `numeric`.", {
+testthat::test_that("T2.19 An error when `x_ticks` is not `NULL` or a `numeric`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -326,7 +337,7 @@ testthat::test_that("T2.18 An error when `x_ticks` is not `NULL` or a `numeric`.
   
 })
 
-testthat::test_that("T2.19 An error when `y_ticks` is not `NULL` or a `numeric`.", {
+testthat::test_that("T2.20 An error when `y_ticks` is not `NULL` or a `numeric`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -339,7 +350,7 @@ testthat::test_that("T2.19 An error when `y_ticks` is not `NULL` or a `numeric`.
   
 })
 
-testthat::test_that("T2.20 No error when a valid option is passed to `legend_position`.", {
+testthat::test_that("T2.21 No error when a valid option is passed to `legend_position`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -353,7 +364,7 @@ testthat::test_that("T2.20 No error when a valid option is passed to `legend_pos
   
 })
 
-testthat::test_that("T2.21 An error when the string is not amongst the valid options for `legend_position`.", {
+testthat::test_that("T2.22 An error when the string is not amongst the valid options for `legend_position`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -362,7 +373,7 @@ testthat::test_that("T2.21 An error when the string is not amongst the valid opt
   
 })
 
-testthat::test_that("T2.22 An error when an undefined option is passed to `legend_position`.", {
+testthat::test_that("T2.23 An error when an undefined option is passed to `legend_position`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -412,7 +423,7 @@ testthat::test_that("T2.22 An error when an undefined option is passed to `legen
   
 })
 
-# Requirement T3 ----------------------------------------------------------
+# Requirement T3 ---------------------------------------------------------------
 
 testthat::context("visr_plot - T3. The y-axis properties are correctly deducted from the provided `fun` when applying `visR::visr()` to a `survfit` object.")
 
@@ -480,7 +491,7 @@ testthat::test_that("T3.6 An error when `fun` is neither a `character` string no
   
 })
 
-# Requirement T4 ----------------------------------------------------------
+# Requirement T4 ---------------------------------------------------------------
 
 testthat::context("visr_plot - T4. Invalid parameters are captured when applying `visR::visr()` to an `attrition` object and respective warnings/errors are thrown.")
 
@@ -870,4 +881,4 @@ testthat::test_that("T4.19 An error when `border` is not a `character` string.",
   
 })
 
-# END ---------------------------------------------------------------------
+# END --------------------------------------------------------------------------

--- a/tests/testthat/test-visr_plot.R
+++ b/tests/testthat/test-visr_plot.R
@@ -199,11 +199,13 @@ testthat::test_that("T2.8 When `x_label` is `NULL` and the `survfit` object does
   
   names(survfit_object)[which(names(survfit_object) == "PARAM")] <- "visR"
   
-  gg <- survfit_object %>% visR::visr(y_label = NULL)
+  gg <- survfit_object %>% visR::visr(x_label = NULL)
   
   ggb <- ggplot2::ggplot_build(gg)
   
-  testthat::expect_true("time" %in% ggb$layout$panel_params[[1]]$x$name)
+  # Ensures that the label is pulled from gg$labels$x
+  testthat::expect_true("waiver" %in% class(ggb$layout$panel_params[[1]]$x$name))
+  testthat::expect_true("time" %in% gg$labels$x)
   
 })
 

--- a/tests/testthat/test-visr_plot.R
+++ b/tests/testthat/test-visr_plot.R
@@ -18,14 +18,21 @@
 #' T2.5 No error when `y_ticks` is `NULL` or a `numeric` value.
 #' T2.6 No error when a valid option is passed to `legend_position`.
 #' T2.7 An error when `x_label` is not `NULL`, a `character` string or an `expression`.
-#' T2.8 When `x_label` is `NULL` and the `survfit` object doesn't have a `PARAM` column, the `x_label` is set to "time".
-#' T2.9 An error when `y_label` is not `NULL`, a `character` string or an `expression`.
-#' T2.10 An error when `x_units` is not `NULL` or a `character` string.
-#' T2.11 An error when `x_ticks` is not `NULL` or a `numeric`.
-#' T2.12 An error when `y_ticks` is not `NULL` or a `numeric`.
-#' T2.13 No error when a valid option is passed to `legend_position`.
-#' T2.14 An error when the string is not amongst the valid options for `legend_position`.
-#' T2.15 An error when an undefined option is passed to `legend_position`.
+#' T2.8 No warning when `x_label` is `NULL` and the `survfit` object has a `PARAM` and a `PARAMCD` column.
+#' T2.9 No warning when `x_label` is `NULL` and the `survfit` object has a `PARAM` but no `PARAMCD` column.
+#' T2.10 No warning when `x_label` is `NULL` and the `survfit` object has no `PARAM` but a `PARAMCD` column.
+#' T2.11 A warning when `x_label` is `NULL` and the `survfit` object has no `PARAM` and no `PARAMCD` column.
+#' T2.12 When `x_label` is `NULL` and the `survfit` object does have a `PARAM` column, the `x_label` is set to `PARAM`.
+#' T2.13 When `x_label` is `NULL` and the `survfit` object does not have a `PARAM` but a `PARAMCD` column, the `x_label` is set to `PARAMCD`.
+#' T2.14 When `x_label` is `NULL` and the `survfit` object does have a `PARAM` but no `PARAMCD` column, the `x_label` is set to `PARAM`.
+#' T2.15 When `x_label` is `NULL` and the `survfit` object does not have a `PARAM` or `PARAMCD` column, the `x_label` is `NULL`.
+#' T2.16 An error when `y_label` is not `NULL`, a `character` string or an `expression`.
+#' T2.17 An error when `x_units` is not `NULL` or a `character` string.
+#' T2.18 An error when `x_ticks` is not `NULL` or a `numeric`.
+#' T2.19 An error when `y_ticks` is not `NULL` or a `numeric`.
+#' T2.20 No error when a valid option is passed to `legend_position`.
+#' T2.21 An error when the string is not amongst the valid options for `legend_position`.
+#' T2.22 An error when an undefined option is passed to `legend_position`.
 #' T3. The y-axis properties are correctly deducted from the provided `fun` when applying `visR::visr()` to a `survfit` object.
 #' T3.1 No error when `y_label` is `NULL` and `fun` is one of the valid string options.
 #' T3.2 An error when `y_label` is `NULL`, `fun` is a string but not one of the valid options.
@@ -33,7 +40,8 @@
 #' T3.4 An error when `y_label` is `NULL` and `fun` is a function.
 #' T3.5 A warning when the provided function causes undefined values, f.e. log(-log(2)).
 #' T3.6 An error when `fun` is neither a `character` string nor a function.
-#' T4. Invalid parameters are captured when applying `visR::visr()` to an `attrition` object and respective warnings/errors are thrown.#' T4.1 No error when `description_column_name` is a `character` string that is found in the colnames of the `attrition` object.
+#' T4. Invalid parameters are captured when applying `visR::visr()` to an `attrition` object and respective warnings/errors are thrown.
+#' T4.1 No error when `description_column_name` is a `character` string that is found in the colnames of the `attrition` object.
 #' T4.2 No error when `value_column_name` is a `character` string that is found in the colnames of the `attrition` object.
 #' T4.3 No error when `complement_column_name` is a `character` string that is found in the colnames of the `attrition` object.
 #' T4.4 No error when `box_width` is a `numeric` value.
@@ -52,6 +60,7 @@
 #' T4.17 An error when `fill` is not a `character` string.
 #' T4.18 An error when `border` is a `character` string but not a valid colour.
 #' T4.19 An error when `border` is not a `character` string.
+
 
 # Requirement T1 ----------------------------------------------------------
 
@@ -192,24 +201,93 @@ testthat::test_that("T2.7 An error when `x_label` is not `NULL`, a `character` s
   
 })
 
-testthat::test_that("T2.8 When `x_label` is `NULL` and the `survfit` object doesn't have a `PARAM` column, the `x_label` is set to \"time\".", {
+testthat::test_that("T2.8 No warning when `x_label` is `NULL` and the `survfit` object has a `PARAM` and a `PARAMCD` column.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
   
-  names(survfit_object)[which(names(survfit_object) == "PARAM")] <- "visR"
-  
-  gg <- survfit_object %>% visR::visr(x_label = NULL)
-  
-  ggb <- ggplot2::ggplot_build(gg)
-  
-  # Ensures that the label is pulled from gg$labels$x
-  testthat::expect_true("waiver" %in% class(ggb$layout$panel_params[[1]]$x$name))
-  testthat::expect_true("time" %in% gg$labels$x)
+  testthat::expect_warning(survfit_object %>% visR::visr(x_label = NULL), NA)
   
 })
 
-testthat::test_that("T2.9 An error when `y_label` is not `NULL`, a `character` string or an `expression`.", {
+testthat::test_that("T2.9 No warning when `x_label` is `NULL` and the `survfit` object has a `PARAM` but no `PARAMCD` column.", {
+  
+  survfit_object <- adtte %>%
+    dplyr::select(-PARAMCD) %>%
+    visR::estimate_KM("SEX") 
+  
+  testthat::expect_warning(survfit_object %>% visR::visr(x_label = NULL), NA)
+  
+})
+
+testthat::test_that("T2.10 No warning when `x_label` is `NULL` and the `survfit` object has no `PARAM` but a `PARAMCD` column.", {
+  
+  survfit_object <- adtte %>%
+    dplyr::select(-PARAM) %>%
+    visR::estimate_KM("SEX") 
+  
+  testthat::expect_warning(survfit_object %>% visR::visr(x_label = NULL), NA)
+  
+})
+
+testthat::test_that("T2.11 A warning when `x_label` is `NULL` and the `survfit` object has no `PARAM` and no `PARAMCD` column.", {
+  
+  survfit_object <- adtte %>%
+    dplyr::select(-c(PARAM, PARAMCD)) %>%
+    visR::estimate_KM("SEX") 
+  
+  testthat::expect_warning(survfit_object %>% visR::visr(x_label = NULL))
+  
+})
+
+testthat::test_that("T2.12 When `x_label` is `NULL` and the `survfit` object does have a `PARAM` column, the `x_label` is set to `PARAM`.", {
+  
+  survfit_object <- adtte %>%
+    visR::estimate_KM("SEX") 
+  
+  gg <- survfit_object %>% visR::visr(x_label = NULL)
+  
+  testthat::expect_true("Time to First Dermatologic Event" %in% gg$labels$x)
+  
+})
+
+testthat::test_that("T2.13 When `x_label` is `NULL` and the `survfit` object does not have a `PARAM` but a `PARAMCD` column, the `x_label` is set to `PARAMCD`.", {
+  
+  survfit_object <- adtte %>%
+    dplyr::select(-PARAM) %>%
+    visR::estimate_KM("SEX") 
+  
+  gg <- survfit_object %>% visR::visr(x_label = NULL)
+  
+  testthat::expect_true("TTDE" %in% gg$labels$x)
+  
+})
+
+testthat::test_that("T2.14 When `x_label` is `NULL` and the `survfit` object does have a `PARAM` but no `PARAMCD` column, the `x_label` is set to `PARAM`.", {
+  
+  survfit_object <- adtte %>%
+    dplyr::select(-PARAMCD) %>%
+    visR::estimate_KM("SEX") 
+  
+  gg <- survfit_object %>% visR::visr(x_label = NULL)
+  
+  testthat::expect_true("Time to First Dermatologic Event" %in% gg$labels$x)
+  
+})
+
+testthat::test_that("T2.15 When `x_label` is `NULL` and the `survfit` object does not have a `PARAM` or `PARAMCD` column, the `x_label` is `NULL`.", {
+  
+  survfit_object <- adtte %>%
+    dplyr::select(-c(PARAM, PARAMCD)) %>%
+    visR::estimate_KM("SEX") 
+  
+  suppressWarnings(gg <- survfit_object %>% visR::visr(x_label = NULL))
+  
+  testthat::expect_true(is.null(gg$labels$x))
+  
+})
+
+testthat::test_that("T2.16 An error when `y_label` is not `NULL`, a `character` string or an `expression`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -222,7 +300,7 @@ testthat::test_that("T2.9 An error when `y_label` is not `NULL`, a `character` s
   
 })
 
-testthat::test_that("T2.10 An error when `x_units` is not `NULL` or a `character` string.", {
+testthat::test_that("T2.17 An error when `x_units` is not `NULL` or a `character` string.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -235,7 +313,7 @@ testthat::test_that("T2.10 An error when `x_units` is not `NULL` or a `character
   
 })
 
-testthat::test_that("T2.11 An error when `x_ticks` is not `NULL` or a `numeric`.", {
+testthat::test_that("T2.18 An error when `x_ticks` is not `NULL` or a `numeric`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -248,7 +326,7 @@ testthat::test_that("T2.11 An error when `x_ticks` is not `NULL` or a `numeric`.
   
 })
 
-testthat::test_that("T2.12 An error when `y_ticks` is not `NULL` or a `numeric`.", {
+testthat::test_that("T2.19 An error when `y_ticks` is not `NULL` or a `numeric`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -261,7 +339,7 @@ testthat::test_that("T2.12 An error when `y_ticks` is not `NULL` or a `numeric`.
   
 })
 
-testthat::test_that("T2.13 No error when a valid option is passed to `legend_position`.", {
+testthat::test_that("T2.20 No error when a valid option is passed to `legend_position`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -275,7 +353,7 @@ testthat::test_that("T2.13 No error when a valid option is passed to `legend_pos
   
 })
 
-testthat::test_that("T2.14 An error when the string is not amongst the valid options for `legend_position`.", {
+testthat::test_that("T2.21 An error when the string is not amongst the valid options for `legend_position`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 
@@ -284,7 +362,7 @@ testthat::test_that("T2.14 An error when the string is not amongst the valid opt
   
 })
 
-testthat::test_that("T2.15 An error when an undefined option is passed to `legend_position`.", {
+testthat::test_that("T2.22 An error when an undefined option is passed to `legend_position`.", {
   
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX") 


### PR DESCRIPTION
Very minor change that however fixes the previous incompatibility with ggplot2s' xlab/ylab commands.

Adresses issue https://github.com/openpharma/visR/issues/207

Rough troubleshooting train of thought:
a) By inspecting the plot components I noticed that the desired label actually ends up in the plot data.
b) Experiment around with priorities of ggplot scales and labels
c) We're currently setting the labels through the scales which seems to make them "write-protected" to the xlab/ylab commands.