### PR TITLE
testthat file dedicated to verify compliance with CRAN guidelines 

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -43,6 +43,79 @@ map_numbers_to_new_range <- function(numbers, lower, upper) {
   
 }
 
+#' A helper function to get all files in the ~/R/ folder
+#' @keywords internal
+
+get_files_in_R_folder <- function() {
+  
+  R_files <- base::list.files(path = base::paste0(base::getwd(), "/../../R"), 
+                                pattern = "*.R", 
+                                full.names = TRUE)
+  
+  return(unlist(R_files))
+  
+}
+
+#' A helper function to get all files in the ~/tests/testthat/ folder
+#' @keywords internal
+
+get_files_in_test_folder <- function() {
+  
+  test_files <- base::list.files(path = base::getwd(), 
+                                 pattern = "*.R", 
+                                 full.names = TRUE)
+  
+  return(unlist(test_files))
+  
+}
+
+#' A helper function to get all files in the ~/man/ folder
+#' @keywords internal
+
+get_files_in_man_folder <- function() {
+  
+  man_files <- base::list.files(path = base::paste0(base::getwd(), "/../../man"), 
+                                pattern = "*.Rd", 
+                                full.names = TRUE)
+  
+  return(unlist(man_files))
+  
+}
+
+#' A helper function to get all files in the ~/vignettes/ folder
+#' @keywords internal
+
+get_files_in_vignettes_folder <- function() {
+  
+  vignette_files <- base::list.files(path = base::paste0(base::getwd(), "/../../vignettes"), 
+                                     pattern = "*.Rmd", 
+                                     full.names = TRUE)
+  
+  return(unlist(vignette_files))
+  
+}
+
+#' A helper function to conditionally retrieve files of the package
+#' @keywords internal
+
+get_visR_files <- function(functions = FALSE,
+                           tests = FALSE,
+                           documentation = FALSE,
+                           vignettes = FALSE,
+                           remove_watchdog = TRUE) {
+  
+  files <- list()
+  
+  if (functions)     {files <- c(files, get_files_in_R_folder())}
+  if (tests)         {files <- c(files, get_files_in_test_folder())}
+  if (documentation) {files <- c(files, get_files_in_man_folder())}
+  if (vignettes)     {files <- c(files, get_files_in_vignettes_folder())}
+  
+  if (remove_watchdog) {files <- files[!grepl("test-CRAN_watchdog.R", files)] }
+  
+  return(unlist(files))
+  
+}
 
 # get_pvalue - Results to compare against ---------------------------------
 

--- a/tests/testthat/test-CRAN_watchdog.R
+++ b/tests/testthat/test-CRAN_watchdog.R
@@ -2,18 +2,19 @@
 #' @section Last updated by:
 #' Tim Treis
 #' @section Last update date:
-#' 05-JULY-2021
+#' 06-JULY-2021
 
-# Specifications ----------------------------------------------------------
-#' T1. Our codebase doesn't violate CRAN style-guidelines
-#' T1.1 TRUE/FALSE are used instead of T/F
-#' T1.2 Each function documentation contains a \value{} tag 
+# Specifications ---------------------------------------------------------------
+#' T1. Our codebase doesn't violate CRAN style-guidelines.
+#' T1.1 TRUE/FALSE are used instead of T/F.
+#' T1.2 Each function documentation contains a \value{} tag.
+#' T1.3 The existence of packages is not checked through 'installed.packages()'.
 
-# Requirement T1 ----------------------------------------------------------
+# Requirement T1 ---------------------------------------------------------------
 
-context("CRAN_watchdog - T1. Our codebase doesn't violate CRAN style-guidelines")
+context("CRAN_watchdog - T1. Our codebase doesn't violate CRAN style-guidelines.")
 
-testthat::test_that("T1.1 TRUE/FALSE are used instead of T/F",{
+testthat::test_that("T1.1 TRUE/FALSE are used instead of T/F.",{
   
   test_files <- get_visR_files(functions = TRUE,
                                tests = TRUE,
@@ -44,13 +45,13 @@ testthat::test_that("T1.1 TRUE/FALSE are used instead of T/F",{
     }
   }
   
-  if (base::nrow(CRAN_incompabilities) > 0) {print(CRAN_incompabilities)}
+  if (base::nrow(CRAN_incompabilities) > 0) { print(CRAN_incompabilities) }
   
   testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
   
 })
 
-testthat::test_that("T1.2 Each function documentation contains a \value{} tag ",{
+testthat::test_that("T1.2 Each function documentation contains a \value{} tag.",{
   
   test_files <- get_visR_files(documentation = TRUE)
   
@@ -86,11 +87,40 @@ testthat::test_that("T1.2 Each function documentation contains a \value{} tag ",
     }
   }
   
-  if (base::nrow(CRAN_incompabilities) > 0) {print(CRAN_incompabilities)}
+  if (base::nrow(CRAN_incompabilities) > 0) { print(CRAN_incompabilities) }
   
   testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
   
 })
 
-# END OF CODE ----------------------------------------------------------
+testthat::test_that("T1.3 The existence of packages is not checked through 'installed.packages()'.",{
+  
+  # installed.packages might be slow on CRAN servers
+  
+  test_files <- get_visR_files(functions = TRUE,
+                               tests = TRUE,
+                               documentation = TRUE,
+                               vignettes = TRUE)
+  
+  CRAN_incompabilities <- data.frame()
+  
+  for (test_file in test_files) {
+      
+    hits <- base::grep("\\\\installed.packages", base::readLines(test_file, warn = FALSE))
+    
+    if (length(hits) > 0) {
+      
+      tmp <- data.frame("line" = hits)
+      tmp[["file"]] <- test_file
+      CRAN_incompabilities <- base::rbind(CRAN_incompabilities, tmp)
+        
+    }
+  }
+  
+  if (base::nrow(CRAN_incompabilities) > 0) { print(CRAN_incompabilities) }
+  
+  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  
+})
 
+# END OF CODE ------------------------------------------------------------------

--- a/tests/testthat/test-CRAN_watchdog.R
+++ b/tests/testthat/test-CRAN_watchdog.R
@@ -10,6 +10,7 @@
 #' T1.2 Each function documentation contains a \value{} tag.
 #' T1.3 The existence of packages is not checked through 'installed.packages()'.
 #' T1.4 No \dontrun{} tags unless the code actually takes a long time.
+#' T1.5 The use of 'options()' is immediately preemptively reverted.
 
 # Requirement T1 ---------------------------------------------------------------
 
@@ -141,6 +142,42 @@ testthat::test_that("T1.4 No \\dontrun{} tags unless the code actually takes a l
     if (sum(grepl(exceptions_collapsed, test_file)) == 0) {
       
       hits <- base::grep("\\\\dontrun\\{", base::readLines(test_file, warn = FALSE))
+      
+      if (length(hits) > 0) {
+        
+        tmp <- data.frame("line" = hits)
+        tmp[["file"]] <- test_file
+        CRAN_incompabilities <- base::rbind(CRAN_incompabilities, tmp)
+        
+      }
+    }
+  }
+  
+  if (base::nrow(CRAN_incompabilities) > 0) { print(CRAN_incompabilities) }
+  
+  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  
+})
+
+testthat::test_that("T1.5 The use of 'options()' is immediately preemptively reverted.",{
+  
+  test_files <- get_visR_files(functions = TRUE,
+                               tests = TRUE,
+                               documentation = TRUE,
+                               vignettes = TRUE)
+  
+  # List of files in which we don't expect a return value.
+  exceptions <- list("Time_to_event_analysis.Rmd",
+                     "CDISC_ADaM.Rmd")
+  exceptions_collapsed <- paste(exceptions, collapse = "|")
+  
+  CRAN_incompabilities <- data.frame()
+  
+  for (test_file in test_files) {
+    
+    if (sum(grepl(exceptions_collapsed, test_file)) == 0) {
+      
+      hits <- base::grep("[\\n\\r\\s]options\\(", base::readLines(test_file, warn = FALSE))
       
       if (length(hits) > 0) {
         

--- a/tests/testthat/test-CRAN_watchdog.R
+++ b/tests/testthat/test-CRAN_watchdog.R
@@ -167,8 +167,7 @@ testthat::test_that("T1.5 The use of 'options()' is immediately preemptively rev
                                vignettes = TRUE)
   
   # List of files in which we don't expect a return value.
-  exceptions <- list("Time_to_event_analysis.Rmd",
-                     "CDISC_ADaM.Rmd")
+  exceptions <- list("Time_to_event_analysis.Rmd", "CDISC_ADaM.Rmd")
   exceptions_collapsed <- paste(exceptions, collapse = "|")
   
   CRAN_incompabilities <- data.frame()
@@ -177,7 +176,7 @@ testthat::test_that("T1.5 The use of 'options()' is immediately preemptively rev
     
     if (sum(grepl(exceptions_collapsed, test_file)) == 0) {
       
-      hits <- base::grep("[\\n\\r\\s]options\\(", base::readLines(test_file, warn = FALSE))
+      hits <- base::grep("^options\\(", base::readLines(test_file, warn = FALSE))
       
       if (length(hits) > 0) {
         

--- a/tests/testthat/test-CRAN_watchdog.R
+++ b/tests/testthat/test-CRAN_watchdog.R
@@ -1,0 +1,99 @@
+#' @title Specifications CRAN_watchdog
+#' @section Last updated by:
+#' Tim Treis
+#' @section Last update date:
+#' 05-JULY-2021
+
+# Specifications ----------------------------------------------------------
+#' T1. Our codebase doesn't violate CRAN style-guidelines
+#' T1.1 TRUE/FALSE are used instead of T/F
+#' T1.2 Each function documentation contains a \value{} tag 
+
+# Requirement T1 ----------------------------------------------------------
+
+context("CRAN_watchdog - T1. Our codebase doesn't violate CRAN style-guidelines")
+
+testthat::test_that("T1.1 TRUE/FALSE are used instead of T/F",{
+  
+  test_files <- base::list.files(path = base::getwd(), 
+                                 pattern = "*.R", 
+                                 full.names = FALSE)
+  
+  # Remove this file
+  test_files <- test_files[test_files != "test-CRAN_watchdog.R"] 
+  
+  patterns <- list("=T,",  "=T ",  "=T)",
+                   "=F,",  "=F ",  "=F)",
+                   "= T,", "= T ", "= T)",
+                   "= F,", "= F ", "= F)")
+  
+  CRAN_incompabilities <- data.frame()
+  
+  for (test_file in test_files) {
+    
+    for (pattern in patterns) {
+      
+      hits <- base::grep(pattern, base::readLines(test_file, warn = FALSE))
+      
+      if (base::length(hits) > 0) {
+        
+        tmp <- data.frame("line" = hits)
+        tmp[["file"]] <- test_file
+        tmp[["issue"]] <- pattern
+        CRAN_incompabilities <- base::rbind(CRAN_incompabilities, tmp)
+        
+      }
+    }
+  }
+  
+  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  
+})
+
+testthat::test_that("T1.2 Each function documentation contains a \value{} tag ",{
+  
+  test_files <- base::list.files(path = base::paste0(base::getwd(), "/../../man"), 
+                                 pattern = "*.Rd", 
+                                 full.names = TRUE)
+  
+  # List of files in which we don't expect a return value.
+  
+  exceptions <- list("adtte.Rd",
+                     "brca_cohort.Rd",
+                     "visR-Global.Rd")
+  exceptions_collapsed <- paste(exceptions, collapse = "|")
+  
+  CRAN_incompabilities <- data.frame()
+  
+  for (test_file in test_files) {
+    
+    if (sum(grepl(exceptions_collapsed, test_file)) == 0) {
+      
+      name_hits <- base::grep("\\\\name\\{", base::readLines(test_file, warn = FALSE))
+      value_hits <- base::grep("\\\\value\\{", base::readLines(test_file, warn = FALSE))
+      
+      # The number of \name{} and \value{} should be the same since this means 
+      # that each function has a return value.
+      
+      if (length(name_hits) != length(value_hits)) {
+        
+        name_hits  <- base::ifelse(length(name_hits) == 0, NA, name_hits)
+        value_hits <- base::ifelse(length(name_hits) == 0, NA, value_hits)
+        
+        tmp <- data.frame("name_line" = name_hits)
+        tmp[["value_line"]] <- value_hits
+        tmp[["file"]] <- test_file
+        CRAN_incompabilities <- base::rbind(CRAN_incompabilities, tmp)
+        
+      }
+    }
+  }
+  
+  print(CRAN_incompabilities)
+  
+  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  
+})
+
+# END OF CODE ----------------------------------------------------------
+

--- a/tests/testthat/test-CRAN_watchdog.R
+++ b/tests/testthat/test-CRAN_watchdog.R
@@ -15,13 +15,11 @@ context("CRAN_watchdog - T1. Our codebase doesn't violate CRAN style-guidelines"
 
 testthat::test_that("T1.1 TRUE/FALSE are used instead of T/F",{
   
-  test_files <- base::list.files(path = base::getwd(), 
-                                 pattern = "*.R", 
-                                 full.names = FALSE)
-  
-  # Remove this file
-  test_files <- test_files[test_files != "test-CRAN_watchdog.R"] 
-  
+  test_files <- get_visR_files(functions = TRUE,
+                               tests = TRUE,
+                               documentation = TRUE,
+                               vignettes = TRUE)
+
   patterns <- list("=T,",  "=T ",  "=T)",
                    "=F,",  "=F ",  "=F)",
                    "= T,", "= T ", "= T)",
@@ -46,18 +44,17 @@ testthat::test_that("T1.1 TRUE/FALSE are used instead of T/F",{
     }
   }
   
+  if (base::nrow(CRAN_incompabilities) > 0) {print(CRAN_incompabilities)}
+  
   testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
   
 })
 
 testthat::test_that("T1.2 Each function documentation contains a \value{} tag ",{
   
-  test_files <- base::list.files(path = base::paste0(base::getwd(), "/../../man"), 
-                                 pattern = "*.Rd", 
-                                 full.names = TRUE)
+  test_files <- get_visR_files(documentation = TRUE)
   
   # List of files in which we don't expect a return value.
-  
   exceptions <- list("adtte.Rd",
                      "brca_cohort.Rd",
                      "visR-Global.Rd")
@@ -89,7 +86,7 @@ testthat::test_that("T1.2 Each function documentation contains a \value{} tag ",
     }
   }
   
-  print(CRAN_incompabilities)
+  if (base::nrow(CRAN_incompabilities) > 0) {print(CRAN_incompabilities)}
   
   testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
   

--- a/tests/testthat/test-CRAN_watchdog.R
+++ b/tests/testthat/test-CRAN_watchdog.R
@@ -9,6 +9,7 @@
 #' T1.1 TRUE/FALSE are used instead of T/F.
 #' T1.2 Each function documentation contains a \value{} tag.
 #' T1.3 The existence of packages is not checked through 'installed.packages()'.
+#' T1.4 No \dontrun{} tags unless the code actually takes a long time.
 
 # Requirement T1 ---------------------------------------------------------------
 
@@ -114,6 +115,40 @@ testthat::test_that("T1.3 The existence of packages is not checked through 'inst
       tmp[["file"]] <- test_file
       CRAN_incompabilities <- base::rbind(CRAN_incompabilities, tmp)
         
+    }
+  }
+  
+  if (base::nrow(CRAN_incompabilities) > 0) { print(CRAN_incompabilities) }
+  
+  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  
+})
+
+testthat::test_that("T1.4 No \\dontrun{} tags unless the code actually takes a long time.",{
+  
+  test_files <- get_visR_files(documentation = TRUE)
+  
+  # List of files in which we don't expect a return value.
+  exceptions <- list("adtte.Rd",
+                     "brca_cohort.Rd",
+                     "visR-Global.Rd")
+  exceptions_collapsed <- paste(exceptions, collapse = "|")
+  
+  CRAN_incompabilities <- data.frame()
+  
+  for (test_file in test_files) {
+    
+    if (sum(grepl(exceptions_collapsed, test_file)) == 0) {
+      
+      hits <- base::grep("\\\\dontrun\\{", base::readLines(test_file, warn = FALSE))
+      
+      if (length(hits) > 0) {
+        
+        tmp <- data.frame("line" = hits)
+        tmp[["file"]] <- test_file
+        CRAN_incompabilities <- base::rbind(CRAN_incompabilities, tmp)
+        
+      }
     }
   }
   


### PR DESCRIPTION
This test automatically scans the relevant parts of our codebase for possible violations of additional style guidelines we received during the CRAN submission process. Generally, a list of files is retrieved which is then searched analysed using a regex pattern specific to the respective issue. If found, the test fails and the file and line of the issue are printed into the test log.

```
# Specifications ---------------------------------------------------------------
#' T1. Our codebase doesn't violate CRAN style-guidelines.
#' T1.1 TRUE/FALSE are used instead of T/F.
#' T1.2 Each function documentation contains a \value{} tag.
#' T1.3 The existence of packages is not checked through 'installed.packages()'.
#' T1.4 No \dontrun{} tags unless the code actually takes a long time.
#' T1.5 The use of 'options()' is immediately preemptively reverted.
```