### PR TITLE
Add 'thevalidatoR' gh-action to generate a report on the release

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,36 @@
+---
+name: R Package Validation report
+
+on: # Run this action when a release is published
+  release:
+    types: [published]
+
+jobs:
+  r-pkg-validation:
+    name: Create report 📃
+    runs-on: ubuntu-latest
+    # Set Github token permissions
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+      packages: write
+      deployments: write
+    steps:
+      - name: Checkout repo 🛎
+        uses: actions/checkout@v2
+
+      - name: Build report 🏗
+        uses: insightsengineering/thevalidatoR@main
+        # see parameters above for custom templates and other formats
+
+      # Upload the validation report to the release
+      - name: Upload report to release 🔼
+        if: success()
+        uses: svenstaro/upload-release-action@v2
+        with:
+          file: ./validation_report.pdf
+          asset_name: validation-report.pdf
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          overwrite: false


### PR DESCRIPTION
see https://github.com/marketplace/actions/r-package-validation-report

We added this to the Roche public repos - and one we share with GSK. It basically verbosely installs a package, describing the installation environment and process, and then unit tests, but traces unit tests back to documentation (e.g. maps requirements to testing). 