### PR TITLE
Removes glue dependency

### DIFF
--- a/.github/workflows/rebuild-readme.yaml
+++ b/.github/workflows/rebuild-readme.yaml
@@ -23,7 +23,6 @@ jobs:
           remotes::install_cran("magrittr")
           remotes::install_cran("dplyr")
           remotes::install_cran("ggplot2")
-          remotes::install_cran("glue")
           remotes::install_cran("vdiffr")
           remotes::install_cran("data.table")
           remotes::install_cran("covr")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,6 @@ Suggests:
     rmarkdown,
     hexbin,
     forcats,
-    glue,
     tibble,
     data.table,
     DT,

--- a/R/estimate_KM.R
+++ b/R/estimate_KM.R
@@ -133,8 +133,8 @@ estimate_KM <- function(
 # Calculate survival and add time = 0 to survfit object -------------------
 
  ## Reverse censoring: see ADaM guidelines versus R survival KM analysis
-
-  formula <- stats::as.formula(glue::glue(paste0("survival::Surv(", AVAL, ", 1-", CNSR, ") ~ {main}")))
+  
+  formula <- stats::as.formula(paste0("survival::Surv(", AVAL, ", 1-", CNSR, ") ~ ", main))
 
   survfit_object <- survival::survfit(
     formula, data = data, ...

--- a/README.Rmd
+++ b/README.Rmd
@@ -111,7 +111,6 @@ Please note that the `visR` project is released with a [Contributor Code of Cond
 
 ```{r getcontributions, echo=FALSE, warning=FALSE, message = FALSE}
 library(dplyr)
-library(glue)
 library(ggplot2)
 #library(GithubMetrics) #remotes::install_github("openpharma/GithubMetrics")
 library(gitsum) #remotes::install_github("lorenzwalthert/gitsum")
@@ -145,13 +144,13 @@ local_repo <- parse_log_detailed()
 #   mutate(
 #     blog = case_when(
 #       blog == "" ~ "",
-#       TRUE ~ as.character(glue('<a href="{blog}">link</a>'))
+#       TRUE ~ as.character(paste0('<a href="', blog, '">link</a>'))
 #       ),
 #     author = case_when(
 #       !is.na(name) ~ paste0(name,"(",author,")"),
 #       TRUE ~ author
 #     ),
-#     author = glue('<img src="{avatar}" alt="" height="30"> {author}')
+#     author = paste0('<img src="', avatar, '" alt="" height="30"> ', author)
 #     ) %>%
 #   select(author,commits_all,commits_6months,company,location,blog) %>%
 #   knitr::kable()

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ current focus on developing a stable API.
 | [![R-CMD-check](https://github.com/openpharma/visR/actions/workflows/check-standard.yaml/badge.svg?branch=main)](https://github.com/openpharma/visR/actions/workflows/check-standard.yaml) | `main` branch                                                                |
 | [![pkgdown](https://github.com/openpharma/visR/actions/workflows/makedocs.yml/badge.svg)](https://github.com/openpharma/visR/actions/workflows/makedocs.yml)                               | Documentation building to [Github pages](https://openpharma.github.io/visR/) |
 | [![CRAN status](https://www.r-pkg.org/badges/version/visR)](https://CRAN.R-project.org/package=visR)                                                                                       | Latest CRAN release                                                          |
-| <a href=https://github.com/pharmaR/riskmetric><img src=https://img.shields.io/badge/riskmetric--1.15-green></img></a>                                                                      | `riskmetric` score                                                           |
+| <a href=https://github.com/pharmaR/riskmetric><img src=https://img.shields.io/badge/riskmetric--1.03-green></img></a>                                                                      | `riskmetric` score                                                           |
 
 <!-- badges: end -->
 
@@ -113,12 +113,13 @@ Last time readme built.
 
 ``` r
 covr::package_coverage()
-#> visR Coverage: 99.72%
-#> R/utils_visr.R: 97.67%
+#> visR Coverage: 99.93%
+#> R/visr.R: 99.51%
 #> R/add_annotation.R: 100.00%
 #> R/add_CI.R: 100.00%
 #> R/add_CNSR.R: 100.00%
 #> R/add_highlight.R: 100.00%
+#> R/add_quantiles.R: 100.00%
 #> R/add_risktable.R: 100.00%
 #> R/apply_attrition.R: 100.00%
 #> R/apply_theme.R: 100.00%
@@ -136,5 +137,5 @@ covr::package_coverage()
 #> R/utils_general.R: 100.00%
 #> R/utils_pipe.R: 100.00%
 #> R/utils_table.R: 100.00%
-#> R/visr.R: 100.00%
+#> R/utils_visr.R: 100.00%
 ```


### PR DESCRIPTION
`glue` has been used once in `estimate_KM` and twice in `README.Rmd`. This PR replaces these by `paste0` so that we can remove `glue`  from the dependencies.