### PR TITLE
Adding cumulative events and censored obs to survfit `*_risktable()` fns

### DIFF
--- a/man/add_risktable.Rd
+++ b/man/add_risktable.Rd
@@ -35,11 +35,11 @@ add_risktable(gg, ...)
 
 \item{times}{Numeric vector indicating the times at which the risk set, censored subjects, events are calculated.}
 
-\item{statlist}{Character vector indicating which summary data to present. Current choices are "n.risk" "n.event" "n.censor".
+\item{statlist}{Character vector indicating which summary data to present. Current choices are "n.risk" "n.event" "n.censor", "cumulative.event", "cumulative.censor".
 Default is "n.risk". Competing risk models also have the option of "cumulative.event" and "cumulative.censor"}
 
-\item{label}{Character vector with labels for the statlist. Default matches "n.risk" with "At risk", "n.event" with "Events" and "n.censor"
-with "Censored".}
+\item{label}{Character vector with labels for the statlist. Default matches "n.risk" with "At risk", "n.event" with "Events", "n.censor"
+with "Censored", "cumulative.event" with "Cum. Event", and "cumulative.censor" with "Cum. Censor".}
 
 \item{group}{String indicating the grouping variable for the risk tables.
 Current options are:

--- a/man/get_risktable.Rd
+++ b/man/get_risktable.Rd
@@ -35,11 +35,11 @@ get_risktable(x, ...)
 
 \item{times}{Numeric vector indicating the times at which the risk set, censored subjects, events are calculated.}
 
-\item{statlist}{Character vector indicating which summary data to present. Current choices are "n.risk" "n.event" "n.censor".
+\item{statlist}{Character vector indicating which summary data to present. Current choices are "n.risk" "n.event" "n.censor", "cumulative.event", "cumulative.censor".
 Default is "n.risk". Competing risk models also have the option of "cumulative.event" and "cumulative.censor"}
 
-\item{label}{Character vector with labels for the statlist. Default matches "n.risk" with "At risk", "n.event" with "Events" and "n.censor"
-with "Censored".}
+\item{label}{Character vector with labels for the statlist. Default matches "n.risk" with "At risk", "n.event" with "Events", "n.censor"
+with "Censored", "cumulative.event" with "Cum. Event", and "cumulative.censor" with "Cum. Censor".}
 
 \item{group}{String indicating the grouping variable for the risk tables.
 Current options are:


### PR DESCRIPTION
The `get_risktable.survfit()` and `add_risktable.ggsurvfit()` functions previously return `n.event`, `n.censor`, and `n.risk`. With this update, users can now report `cumulative.event` and `cumulative.censor`.

I know you'll probably want updates to the unit tests! 😆 Let me know how I can update.
closes #309

Examples below!

``` r
library(visR)

estimate_KM(data = adtte) %>%
    visr() %>%
    add_risktable(statlist = c("n.risk", "cumulative.event", "cumulative.censor"))
```

![](https://i.imgur.com/1zZZUjv.png)

``` r
  
estimate_KM(data = adtte, strata = "SEX") %>%
  visr() %>%
  add_risktable(statlist = c("n.risk", "cumulative.event", "cumulative.censor"))
```

![](https://i.imgur.com/BoZnV24.png)

<sup>Created on 2022-01-25 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
