### PR TITLE
Build `README.Rmd` on main branch instead of all PRs

### DIFF
--- a/.github/workflows/rebuild-readme.yaml
+++ b/.github/workflows/rebuild-readme.yaml
@@ -2,7 +2,7 @@ name: Render README
 
 on:
   push:
-    branches: [main, master]
+    branches: [main, master, develop]
 
 jobs:
   render:

--- a/.github/workflows/rebuild-readme.yaml
+++ b/.github/workflows/rebuild-readme.yaml
@@ -1,6 +1,8 @@
 name: Render README
 
-on: [pull_request]
+on:
+  push:
+    branches: [main, master]
 
 jobs:
   render:


### PR DESCRIPTION
closes #340

The workflow that builds the `README.Rmd` is currently run on every pull request. This update builds `README.Rmd` only when the main/master branch is updated. 