### PR TITLE
Added check to `get_pvalue()` 

### DIFF
--- a/R/utils_pipe.R
+++ b/R/utils_pipe.R
@@ -45,3 +45,12 @@ the_lhs <- function() {
     df <- as.character(sub("\\[.*$", "", deparse(call_list[["data"]]))[1])
   }
 }
+
+#' @title Is visR survfit?
+#'
+#' @return logical
+#' @noRd
+is_visr_survfit <- function(x) {
+  # the visr survift object saves a quosure instead of a call
+  inherits(x, "survfit") && rlang::is_quosure(x$call)
+}

--- a/tests/testthat/test-get_pvalue.R
+++ b/tests/testthat/test-get_pvalue.R
@@ -31,6 +31,9 @@
 #' T4.6 The Chisq statistic has the same precision as the pvalue
 #' T5. Piped datasets still return accurate results
 #' T5.1 P-values are accurate when a filtered data frame is piped
+#' T6. Function works with `survival::survfit()` objects
+#' T6.1 Function works with `survival::survfit()` objects
+#' T6.2 Function messages users appropriately when data is piped, and p-value cannot be calculated
 
 # Requirement T1 ----------------------------------------------------------
 
@@ -242,5 +245,27 @@ testthat::test_that("T5.1 P-values are accurate when a filtered data frame is pi
     visR:::.pvalformat()
   testthat::expect_equal(survfit_p, survdiff_p)
 })
+
+# Requirement T6 ---------------------------------------------------------------
+
+testthat::context("get_pvalue - T6. Function works with `survival::survfit()` objects")
+
+testthat::test_that("T6.1 Function works with `survival::survfit()` objects", {
+  expect_error(
+    survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung) %>%
+      get_pvalue(),
+    NA
+  )
+})
+
+testthat::test_that("T6.2 Function messages users appropriately when data is piped, and p-value cannot be calculated",{
+  expect_error(
+    lung %>%
+      survfit(Surv(time, status) ~ sex, data = .) %>%
+      get_pvalue(),
+    "*estimate_KM*" # error message includes reference to `estimate_KM()` function.
+  )
+})
+
 
 # END OF CODE -------------------------------------------------------------


### PR DESCRIPTION
**What changes are proposed in this pull request?**
* Improved error messaging in `check_pvalue()` when there is an error and the survfit object was not created with `estimate_KM()`. (#373)

**Did you include unit tests for the proposed change/bug fix (https://testthat.r-lib.org/)?**
yes

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #373


``` r
library(survival)
library(visR)

lung %>%
  survfit(Surv(time, status) ~ sex, data = .) %>%
  get_pvalue()
#> Error: There was an error calculating the p-values.
#> The 'survfit' object was not created with `visR::estimate_KM()`.
#> The the error will likely be resolved by re-estimating the 'survfit' object with visR.
#> Error in terms.formula(formula, "strata", data = data): object '.' not found
```

<sup>Created on 2022-05-28 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>


--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function should be included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Before you run, begin a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading indicating the latest version. If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
