### PR TITLE
Issue #370 - remove lifecycle status from readme

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: visR
 Title: Clinical Graphs and Tables Adhering to Graphical Principles
-Version: 0.2.0.9006
+Version: 0.2.0.9007
 Authors@R: c(
     person(given = "Mark",
            family = "Baillie", 

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,9 +28,17 @@ riskmetric_score <- "visR" %>%
 
 ```
 
-
-
 # visR <img src='man/figures/logo.png' align="right" height="131.5" />
+
+<!-- badges: start -->
+
+[![Codecov test coverage](https://codecov.io/gh/openpharma/visR/branch/develop/graph/badge.svg)](https://codecov.io/gh/openpharma/visR?branch=main)
+[![R-CMD-check](https://github.com/openpharma/visR/workflows/R-CMD-check/badge.svg)](https://github.com/openpharma/visR/actions)
+[![pkgdown](https://github.com/openpharma/visR/actions/workflows/makedocs.yml/badge.svg)](https://github.com/openpharma/visR/actions/workflows/makedocs.yml)
+[![CRAN status](https://www.r-pkg.org/badges/version/visR)](https://CRAN.R-project.org/package=visR)
+<a href=https://github.com/pharmaR/riskmetric><img src=https://img.shields.io/badge/riskmetric-`r riskmetric_score`-green></img></a>
+<!-- badges: end -->
+
 
 The goal of visR is to enable fit-for-purpose, reusable clinical and medical research focused visualizations and tables with sensible defaults and based on sound [graphical principles](https://graphicsprinciples.github.io/).
 
@@ -48,17 +56,6 @@ We are not judging on what visualisation you chose for your research question, b
 You can read more about the philosophy and architecture in the [repo wiki](https://github.com/openpharma/visR/wiki).
 
 ## Installation
-
-<!-- badges: start -->
-
-[![Codecov test coverage](https://codecov.io/gh/openpharma/visR/branch/develop/graph/badge.svg)](https://codecov.io/gh/openpharma/visR?branch=main)
-[![R-CMD-check](https://github.com/openpharma/visR/workflows/R-CMD-check/badge.svg)](https://github.com/openpharma/visR/actions)
-[![pkgdown](https://github.com/openpharma/visR/actions/workflows/makedocs.yml/badge.svg)](https://github.com/openpharma/visR/actions/workflows/makedocs.yml)
-[![CRAN status](https://www.r-pkg.org/badges/version/visR)](https://CRAN.R-project.org/package=visR)
-<a href=https://github.com/pharmaR/riskmetric><img src=https://img.shields.io/badge/riskmetric-`r riskmetric_score`-green></img></a>
-<!-- badges: end -->
-
-
 
 The easiest way to get `visR` is to install from CRAN:
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -28,6 +28,8 @@ riskmetric_score <- "visR" %>%
 
 ```
 
+
+
 # visR <img src='man/figures/logo.png' align="right" height="131.5" />
 
 The goal of visR is to enable fit-for-purpose, reusable clinical and medical research focused visualizations and tables with sensible defaults and based on sound [graphical principles](https://graphicsprinciples.github.io/).
@@ -45,13 +47,10 @@ We are not judging on what visualisation you chose for your research question, b
 
 You can read more about the philosophy and architecture in the [repo wiki](https://github.com/openpharma/visR/wiki).
 
-## Lifecycle and status
-
-The package is still experimental and under active development with a current focus on developing a stable API. 
+## Installation
 
 <!-- badges: start -->
 
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![Codecov test coverage](https://codecov.io/gh/openpharma/visR/branch/develop/graph/badge.svg)](https://codecov.io/gh/openpharma/visR?branch=main)
 [![R-CMD-check](https://github.com/openpharma/visR/workflows/R-CMD-check/badge.svg)](https://github.com/openpharma/visR/actions)
 [![pkgdown](https://github.com/openpharma/visR/actions/workflows/makedocs.yml/badge.svg)](https://github.com/openpharma/visR/actions/workflows/makedocs.yml)
@@ -60,7 +59,6 @@ The package is still experimental and under active development with a current fo
 <!-- badges: end -->
 
 
-## Installation
 
 The easiest way to get `visR` is to install from CRAN:
 

--- a/README.md
+++ b/README.md
@@ -29,15 +29,10 @@ question, but want to facilitate and support good practice.
 You can read more about the philosophy and architecture in the [repo
 wiki](https://github.com/openpharma/visR/wiki).
 
-## Lifecycle and status
-
-The package is still experimental and under active development with a
-current focus on developing a stable API.
+## Installation
 
 <!-- badges: start -->
 
-[![Lifecycle:
-experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![Codecov test
 coverage](https://codecov.io/gh/openpharma/visR/branch/develop/graph/badge.svg)](https://codecov.io/gh/openpharma/visR?branch=main)
 [![R-CMD-check](https://github.com/openpharma/visR/workflows/R-CMD-check/badge.svg)](https://github.com/openpharma/visR/actions)
@@ -46,8 +41,6 @@ coverage](https://codecov.io/gh/openpharma/visR/branch/develop/graph/badge.svg)]
 status](https://www.r-pkg.org/badges/version/visR)](https://CRAN.R-project.org/package=visR)
 <a href=https://github.com/pharmaR/riskmetric><img src=https://img.shields.io/badge/riskmetric-0.53-green></img></a>
 <!-- badges: end -->
-
-## Installation
 
 The easiest way to get `visR` is to install from CRAN:
 

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -14,7 +14,6 @@ Covid
 DT
 Kaplan
 Karnakata
-Lifecycle
 NCCTG
 ORCID
 PARAM


### PR DESCRIPTION
**What changes are proposed in this pull request?**

Resolves issue #370 

Removes lifecycle badge and text from Readme.Rmd. 
The remaining badges have been placed under the installation section. 

**Which files are involved in this pull request and what changes were made?**

Readme.Rmd

**Did you include unit tests for the proposed change/bug fix (https://testthat.r-lib.org/)?**

N/A

**If there is an GitHub issue associated with this pull request, please provide link.**

closes #370
 
--------------------------------------------------------------------------------

Checklist for PR reviewer

- [x] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [x] If a new function was added, function should be included in `_pkgdown.yml`
- [x] If a bug was fixed, a unit test was added for the bug check
- [x] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [x] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Before you run, begin a fresh R session without any packages loaded. 
- [x] R CMD Check runs without errors, warnings, and notes
- [x] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [x] Has `NEWS.md` been updated with the changes from this pull request under the heading indicating the latest version. If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [x] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [x] Approve Pull Request
- [x] Merge the PR. Please use "Squash and merge".
