### PR TITLE
Removing `testthat::` prefix in unit testing files

### DIFF
--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -101,7 +101,7 @@
 
 .get_test_TOC <- function(path_to_file) {
   txt <- paste(readLines(path_to_file, warn = FALSE), collapse = "\n")
-  tests <- gregexpr("testthat::test_that\\(\\\"(.+?)\"", txt)
+  tests <- gregexpr("test_that\\(\\\"(.+?)\"", txt)
   contexts <- gregexpr("context\\(\\\"(.+?)\"", txt)
 
   context_df <- data.frame("pos" = unlist(contexts))
@@ -125,7 +125,7 @@
   test_df["content"] <- regmatches(txt, tests)
 
   test_df$content <- base::lapply(test_df$content, function(c) {
-    c <- gsub(pattern = "testthat::test_that\\(\\\"T", replacement = "T", x = c)
+    c <- gsub(pattern = "test_that\\(\\\"T", replacement = "T", x = c)
     c <- gsub(pattern = "\"", replacement = "", x = c)
     c
   }) %>% unlist()

--- a/tests/testthat/test-Surv_CNSR.R
+++ b/tests/testthat/test-Surv_CNSR.R
@@ -17,24 +17,24 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("Surv_CNSR - T1. The function returns a Surv object")
+context("Surv_CNSR - T1. The function returns a Surv object")
 
-testthat::test_that("T1.1 The function returns a Surv object", {
-  testthat::expect_error(surv1 <- with(adtte, visR::Surv_CNSR()), NA)
-  testthat::expect_error(surv2 <- with(adtte, visR::Surv_CNSR()), NA)
-  testthat::expect_true(inherits(surv1, "Surv"))
-  testthat::expect_true(inherits(surv2, "Surv"))
+test_that("T1.1 The function returns a Surv object", {
+  expect_error(surv1 <- with(adtte, visR::Surv_CNSR()), NA)
+  expect_error(surv2 <- with(adtte, visR::Surv_CNSR()), NA)
+  expect_true(inherits(surv1, "Surv"))
+  expect_true(inherits(surv2, "Surv"))
 })
 
-testthat::test_that("T1.2 The function is compatible with the survival package", {
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte), NA)
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ SEX, data = adtte), NA)
+test_that("T1.2 The function is compatible with the survival package", {
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte), NA)
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ SEX, data = adtte), NA)
 
-  testthat::expect_error(adtte %>% visR::estimate_KM(formula = Surv_CNSR() ~ 1), NA)
-  testthat::expect_error(adtte %>% visR::estimate_KM(formula = Surv_CNSR() ~ SEX), NA)
+  expect_error(adtte %>% visR::estimate_KM(formula = Surv_CNSR() ~ 1), NA)
+  expect_error(adtte %>% visR::estimate_KM(formula = Surv_CNSR() ~ SEX), NA)
 
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR(AVAL, CNSR) ~ 1, data = adtte), NA)
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR(AVAL, CNSR) ~ SEX, data = adtte), NA)
+  expect_error(survival::survfit(visR::Surv_CNSR(AVAL, CNSR) ~ 1, data = adtte), NA)
+  expect_error(survival::survfit(visR::Surv_CNSR(AVAL, CNSR) ~ SEX, data = adtte), NA)
 
   # WHEN THIS TEST FAILS, THAT IS OUR SIGNAL THAT {survival} HAS BEEN UPDATED ON CRAN!!
   # AT THAT POINT WE SHOULD DO THE FOLLOWING
@@ -43,12 +43,12 @@ testthat::test_that("T1.2 The function is compatible with the survival package",
   #    THIS CAN BE DONE IN TWO WAYS:
   #      1. in the DESCRIPTION file
   #      2. using rlang::check_installed("survival", version = <add required version number>)
-  testthat::expect_error(survival::coxph(visR::Surv_CNSR() ~ SEX, data = adtte))
+  expect_error(survival::coxph(visR::Surv_CNSR() ~ SEX, data = adtte))
 })
 
 
-testthat::test_that("T1.3 The results of the estimation match between Surv_CNSR and Surv with inverted censoring", {
-  testthat::expect_equal(
+test_that("T1.3 The results of the estimation match between Surv_CNSR and Surv with inverted censoring", {
+  expect_equal(
     with(adtte, visR::Surv_CNSR()),
     with(adtte, survival::Surv(AVAL, 1 - CNSR))
   )
@@ -56,54 +56,54 @@ testthat::test_that("T1.3 The results of the estimation match between Surv_CNSR 
   km1 <- adtte %>% visR::estimate_KM(formula = visR::Surv_CNSR() ~ 1)
   km2 <- adtte %>% visR::estimate_KM()
   km1$call <- km2$call <- NULL
-  testthat::expect_equal(km1, km2)
+  expect_equal(km1, km2)
 
   km1 <- adtte %>% visR::estimate_KM(formula = visR::Surv_CNSR() ~ SEX)
   km2 <- adtte %>% visR::estimate_KM(strata = "SEX")
   km1$call <- km2$call <- NULL
-  testthat::expect_equal(km1, km2)
+  expect_equal(km1, km2)
 })
 
 # Requirement T2 ----------------------------------------------------------
 
-testthat::test_that("T2.1 An error when column name specified through AVAL is not present in the environment", {
-  testthat::expect_true(!"AVAL" %in% colnames(survival::lung))
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = survival::lung))
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ sex, data = survival::lung))
+test_that("T2.1 An error when column name specified through AVAL is not present in the environment", {
+  expect_true(!"AVAL" %in% colnames(survival::lung))
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = survival::lung))
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ sex, data = survival::lung))
 
   adtte[["AVAL"]] <- NULL
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte))
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte))
 })
 
-testthat::test_that("T2.2 An error when column name specified through AVAL in the environment is not numeric", {
+test_that("T2.2 An error when column name specified through AVAL in the environment is not numeric", {
   adtte[["AVAL"]] <- as.character(adtte[["AVAL"]])
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte))
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte))
 
-  testthat::expect_error(survival::survfit(visR::Surv_CDISC(AVAL = time) ~ 1, data = survival::lung %>% dplyr::mutate(AVAL = as.character(time))))
+  expect_error(survival::survfit(visR::Surv_CDISC(AVAL = time) ~ 1, data = survival::lung %>% dplyr::mutate(AVAL = as.character(time))))
 })
 
-testthat::test_that("T2.3 A warning when the column specified through AVAL has negative values", {
-  testthat::expect_warning(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte %>% dplyr::mutate(AVAL = AVAL - 10000)))
+test_that("T2.3 A warning when the column specified through AVAL has negative values", {
+  expect_warning(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte %>% dplyr::mutate(AVAL = AVAL - 10000)))
 })
 
-testthat::test_that("T2.4 An error when the column name specified through CNSR is not present in the environment", {
-  testthat::expect_true(!"CNSR" %in% colnames(survival::lung))
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = survival::lung %>% dplyr::rename(AVAL = time)))
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ sex, data = survival::lung %>% dplyr::rename(AVAL = time)))
+test_that("T2.4 An error when the column name specified through CNSR is not present in the environment", {
+  expect_true(!"CNSR" %in% colnames(survival::lung))
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = survival::lung %>% dplyr::rename(AVAL = time)))
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ sex, data = survival::lung %>% dplyr::rename(AVAL = time)))
 
   adtte[["CNSR"]] <- NULL
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte))
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte))
 })
 
-testthat::test_that("T2.5 An error when the column name specified through CNSR in the environment is not numeric", {
+test_that("T2.5 An error when the column name specified through CNSR in the environment is not numeric", {
   adtte[["CNSR"]] <- as.character(adtte[["CNSR"]])
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte))
+  expect_error(survival::survfit(visR::Surv_CNSR() ~ 1, data = adtte))
 
-  testthat::expect_error(survival::survfit(visR::Surv_CDISC(AVAL = time) ~ 1, data = survival::lung %>% dplyr::mutate(CNSR = as.character(status))))
+  expect_error(survival::survfit(visR::Surv_CDISC(AVAL = time) ~ 1, data = survival::lung %>% dplyr::mutate(CNSR = as.character(status))))
 })
 
-testthat::test_that("T2.6 An error when the column name specified through CNSR is not coded as 0/1", {
-  testthat::expect_error(survival::survfit(visR::Surv_CNSR(time, status) ~ 1, data = survival::lung))
+test_that("T2.6 An error when the column name specified through CNSR is not coded as 0/1", {
+  expect_error(survival::survfit(visR::Surv_CNSR(time, status) ~ 1, data = survival::lung))
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-add_CI.R
+++ b/tests/testthat/test-add_CI.R
@@ -19,30 +19,30 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("add_CI - T1. No errors when confidence intervals are added to the plots.")
+context("add_CI - T1. No errors when confidence intervals are added to the plots.")
 
-testthat::test_that("T1.1 No error when the default parameters are used", {
+test_that("T1.1 No error when the default parameters are used", {
   survfit_object <- adtte %>% visR::estimate_KM()
   p <- visR::visr(survfit_object)
 
-  testthat::expect_error(p %>% visR::add_CI(), NA)
+  expect_error(p %>% visR::add_CI(), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CI() %>%
     vdiffr::expect_doppelganger(title = "add_CI_T1_1_no_error_when_default_parameters_are_used")
 })
 
-testthat::test_that("T1.2 No error when `alpha` is a numerical value between [0, 1].", {
+test_that("T1.2 No error when `alpha` is a numerical value between [0, 1].", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
-  testthat::expect_error(p %>% visR::add_CI(alpha = 0), NA)
-  testthat::expect_error(p %>% visR::add_CI(alpha = 0.5), NA)
-  testthat::expect_error(p %>% visR::add_CI(alpha = 1), NA)
+  expect_error(p %>% visR::add_CI(alpha = 0), NA)
+  expect_error(p %>% visR::add_CI(alpha = 0.5), NA)
+  expect_error(p %>% visR::add_CI(alpha = 1), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CI(alpha = 0) %>%
     vdiffr::expect_doppelganger(title = "add_CI_T1_alpha_0")
@@ -54,15 +54,15 @@ testthat::test_that("T1.2 No error when `alpha` is a numerical value between [0,
     vdiffr::expect_doppelganger(title = "add_CI_T1_alpha_1")
 })
 
-testthat::test_that("T1.3 No error when `style` is `ribbon` or `step`.", {
+test_that("T1.3 No error when `style` is `ribbon` or `step`.", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
-  testthat::expect_error(p %>% visR::add_CI(style = "ribbon"), NA)
-  testthat::expect_error(p %>% visR::add_CI(style = "step"), NA)
+  expect_error(p %>% visR::add_CI(style = "ribbon"), NA)
+  expect_error(p %>% visR::add_CI(style = "step"), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CI(style = "ribbon") %>%
     vdiffr::expect_doppelganger(title = "add_CI_T1_3_style_ribbon")
@@ -71,7 +71,7 @@ testthat::test_that("T1.3 No error when `style` is `ribbon` or `step`.", {
     vdiffr::expect_doppelganger(title = "add_CI_T1_3_style_step")
 })
 
-testthat::test_that("T1.4 No error when `linetype` is one of the valid ggplot choices.", {
+test_that("T1.4 No error when `linetype` is one of the valid ggplot choices.", {
   linetypes <- c(
     "blank", "solid", "dashed", "dotted",
     "dotdash", "longdash", "twodash"
@@ -82,17 +82,17 @@ testthat::test_that("T1.4 No error when `linetype` is one of the valid ggplot ch
     visR::visr()
 
   for (i in 1:length(linetypes)) {
-    testthat::expect_error(p %>% visR::add_CI(
+    expect_error(p %>% visR::add_CI(
       style = "step",
       linetype = linetypes[i]
     ), NA)
-    testthat::expect_error(p %>% visR::add_CI(
+    expect_error(p %>% visR::add_CI(
       style = "step",
       linetype = (i - 1)
     ), NA)
   }
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   for (i in 1:length(linetypes)) {
     p %>%
       visR::add_CI(style = "step", linetype = linetypes[i]) %>%
@@ -112,22 +112,22 @@ testthat::test_that("T1.4 No error when `linetype` is one of the valid ggplot ch
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("add_CI - T2. No errors when different amount of strata are used.")
+context("add_CI - T2. No errors when different amount of strata are used.")
 
-testthat::test_that("T2.1 No error when only 1 strata is present.", {
+test_that("T2.1 No error when only 1 strata is present.", {
   p <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
 
-  testthat::expect_error(p %>% visR::add_CI(alpha = 0.5), NA)
+  expect_error(p %>% visR::add_CI(alpha = 0.5), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CI(alpha = 0.5) %>%
     vdiffr::expect_doppelganger(title = "add_CI_T2_1_one_strata")
 })
 
-testthat::test_that("T2.2 No error when 2 or more strata are present", {
+test_that("T2.2 No error when 2 or more strata are present", {
   for (n_strata in c(5, 10, 20)) {
     p <- adtte %>%
       dplyr::mutate(TRTDUR = .map_numbers_to_new_range(
@@ -138,10 +138,10 @@ testthat::test_that("T2.2 No error when 2 or more strata are present", {
       visR::estimate_KM(strata = "TRTDUR") %>%
       visR::visr()
 
-    testthat::expect_error(p %>% visR::add_CI(), NA)
+    expect_error(p %>% visR::add_CI(), NA)
   }
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   for (n_strata in c(5, 10, 20)) {
     p <- adtte %>%
       dplyr::mutate(TRTDUR = .map_numbers_to_new_range(
@@ -164,47 +164,47 @@ testthat::test_that("T2.2 No error when 2 or more strata are present", {
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("add_CI - T3.  Warnings in case of missing data or unexpected arguments are thrown.")
+context("add_CI - T3.  Warnings in case of missing data or unexpected arguments are thrown.")
 
-testthat::test_that("T3.1 Error when `est.lower` and `est.upper` are not present.", {
+test_that("T3.1 Error when `est.lower` and `est.upper` are not present.", {
   survfit_object <- adtte %>% visR::estimate_KM(strata = "SEX")
   p <- survfit_object %>% visR::visr()
 
   are_present_before <- all(c("est.lower", "est.upper") %in% colnames(p$data))
-  testthat::expect_equal(are_present_before, TRUE)
-  testthat::expect_error(p %>% visR::add_CI(), NA)
+  expect_equal(are_present_before, TRUE)
+  expect_error(p %>% visR::add_CI(), NA)
 
   p$data <- p$data %>% dplyr::select(-c(est.lower, est.upper))
   are_present_after <- all(c("est.lower", "est.upper") %in% colnames(p$data))
-  testthat::expect_equal(are_present_after, FALSE)
-  testthat::expect_error(p %>% visR::add_CI())
+  expect_equal(are_present_after, FALSE)
+  expect_error(p %>% visR::add_CI())
 })
 
-testthat::test_that("T3.2 Warning when no valid style was provided.", {
+test_that("T3.2 Warning when no valid style was provided.", {
   survfit_object <- adtte %>% visR::estimate_KM(strata = "SEX")
   p <- survfit_object %>% visR::visr()
 
   warning_message <- "Invalid `style` argument. Setting `style` to `ribbon`."
-  testthat::expect_warning(p %>% visR::add_CI(style = "visR"), warning_message)
+  expect_warning(p %>% visR::add_CI(style = "visR"), warning_message)
 })
 
-testthat::test_that("T3.3 Warning when `alpha` is not in [0, 1].", {
+test_that("T3.3 Warning when `alpha` is not in [0, 1].", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
   warning_message <- "Invalid `alpha` argument, must be between 0 and 1. Setting it to 0.1."
-  testthat::expect_warning(p %>% visR::add_CI(alpha = 5), warning_message)
-  testthat::expect_warning(p %>% visR::add_CI(alpha = -5), warning_message)
+  expect_warning(p %>% visR::add_CI(alpha = 5), warning_message)
+  expect_warning(p %>% visR::add_CI(alpha = -5), warning_message)
 })
 
-testthat::test_that("T3.4 Warning when `style` is `ribbon` but a `linetype` was specified.", {
+test_that("T3.4 Warning when `style` is `ribbon` but a `linetype` was specified.", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
   warning_message <- "Argument `linetype` not used for style ribbon."
-  testthat::expect_warning(
+  expect_warning(
     p %>% visR::add_CI(
       style = "ribbon",
       linetype = 2

--- a/tests/testthat/test-add_CNSR.R
+++ b/tests/testthat/test-add_CNSR.R
@@ -22,94 +22,94 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("add_CNSR - T1. The output plots after adding confidence intervals don't differ from the reviewed plots")
+context("add_CNSR - T1. The output plots after adding confidence intervals don't differ from the reviewed plots")
 
-testthat::test_that("T1.1 No error when censoring is plotted for one strata with default parameters", {
+test_that("T1.1 No error when censoring is plotted for one strata with default parameters", {
   p <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
 
-  testthat::expect_error(p %>% visR::add_CNSR(), NA)
+  expect_error(p %>% visR::add_CNSR(), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CNSR() %>%
     vdiffr::expect_doppelganger(title = "add_CNSR_T1_1_one_strata")
 })
 
-testthat::test_that("T1.2 No error when censoring is plotted for more than one strata with default parameters", {
+test_that("T1.2 No error when censoring is plotted for more than one strata with default parameters", {
   p <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
 
-  testthat::expect_error(p %>% visR::add_CNSR(), NA)
+  expect_error(p %>% visR::add_CNSR(), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CNSR() %>%
     vdiffr::expect_doppelganger(title = "add_CNSR_T1_2_TRTP")
 })
 
-testthat::test_that("T1.3 No error when `shape` is set to an empty string.", {
+test_that("T1.3 No error when `shape` is set to an empty string.", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
-  testthat::expect_error(p %>% visR::add_CNSR(shape = ""), NA)
+  expect_error(p %>% visR::add_CNSR(shape = ""), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CNSR(shape = "") %>%
     vdiffr::expect_doppelganger(title = "add_CNSR_T1_3_shape_empty_string")
 })
 
-testthat::test_that("T1.4 No error when `shape` is set to a numerical in [0-25].", {
+test_that("T1.4 No error when `shape` is set to a numerical in [0-25].", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
-  testthat::expect_error(p %>% visR::add_CNSR(shape = 0), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(shape = 5), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(shape = 10), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(shape = 15), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(shape = 20), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(shape = 25), NA)
+  expect_error(p %>% visR::add_CNSR(shape = 0), NA)
+  expect_error(p %>% visR::add_CNSR(shape = 5), NA)
+  expect_error(p %>% visR::add_CNSR(shape = 10), NA)
+  expect_error(p %>% visR::add_CNSR(shape = 15), NA)
+  expect_error(p %>% visR::add_CNSR(shape = 20), NA)
+  expect_error(p %>% visR::add_CNSR(shape = 25), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CNSR(shape = 15) %>%
     vdiffr::expect_doppelganger(title = "add_CNSR_T1_4_shape_valid_numerical")
 })
 
-testthat::test_that("T1.5 No error when `shape` is set to an atomic string.", {
+test_that("T1.5 No error when `shape` is set to an atomic string.", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
-  testthat::expect_error(p %>% visR::add_CNSR(shape = "a"), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(shape = "B"), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(shape = "0"), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(shape = "."), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(shape = "µ"), NA)
+  expect_error(p %>% visR::add_CNSR(shape = "a"), NA)
+  expect_error(p %>% visR::add_CNSR(shape = "B"), NA)
+  expect_error(p %>% visR::add_CNSR(shape = "0"), NA)
+  expect_error(p %>% visR::add_CNSR(shape = "."), NA)
+  expect_error(p %>% visR::add_CNSR(shape = "µ"), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CNSR(shape = "µ") %>%
     vdiffr::expect_doppelganger(title = "add_CNSR_T1_5_shape_atomic_string")
 })
 
-testthat::test_that("T1.6 No error when `size` is set to a numerical.", {
+test_that("T1.6 No error when `size` is set to a numerical.", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
-  testthat::expect_error(p %>% visR::add_CNSR(size = -500), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(size = -5), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(size = 0), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(size = 5), NA)
-  testthat::expect_error(p %>% visR::add_CNSR(size = 500), NA)
+  expect_error(p %>% visR::add_CNSR(size = -500), NA)
+  expect_error(p %>% visR::add_CNSR(size = -5), NA)
+  expect_error(p %>% visR::add_CNSR(size = 0), NA)
+  expect_error(p %>% visR::add_CNSR(size = 5), NA)
+  expect_error(p %>% visR::add_CNSR(size = 500), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   p %>%
     visR::add_CNSR(size = -5) %>%
     vdiffr::expect_doppelganger(title = "add_CNSR_T1_7_size_negative_numerical")
@@ -124,9 +124,9 @@ testthat::test_that("T1.6 No error when `size` is set to a numerical.", {
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("add_CNSR - T2. Warnings/errors in case of missing data or weird arguments are thrown.")
+context("add_CNSR - T2. Warnings/errors in case of missing data or weird arguments are thrown.")
 
-testthat::test_that("T2.1 Error when object is not of class `ggsurvfit`.", {
+test_that("T2.1 Error when object is not of class `ggsurvfit`.", {
   p <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
@@ -134,58 +134,58 @@ testthat::test_that("T2.1 Error when object is not of class `ggsurvfit`.", {
   p_without_ggsurvfit <- p
   class(p_without_ggsurvfit) <- class(p)[class(p) != "ggsurvfit"]
 
-  testthat::expect_error(p %>% visR::add_CNSR(), NA)
-  testthat::expect_error(p_without_ggsurvfit %>% visR::add_CNSR())
+  expect_error(p %>% visR::add_CNSR(), NA)
+  expect_error(p_without_ggsurvfit %>% visR::add_CNSR())
 })
 
-testthat::test_that("T2.2 Warning when a character is provided as `size`", {
+test_that("T2.2 Warning when a character is provided as `size`", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
   expected_warning <- "Invalid `size` specified. Setting it to 2."
-  testthat::expect_warning(p %>% visR::add_CNSR(size = "a"), expected_warning)
+  expect_warning(p %>% visR::add_CNSR(size = "a"), expected_warning)
 })
 
-testthat::test_that("T2.3 Warning when NULL or NA are provided as `size`.", {
+test_that("T2.3 Warning when NULL or NA are provided as `size`.", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
   expected_warning <- "Invalid `size` specified. Setting it to 2."
-  testthat::expect_warning(p %>% visR::add_CNSR(size = NULL), expected_warning)
-  testthat::expect_warning(p %>% visR::add_CNSR(size = NA), expected_warning)
+  expect_warning(p %>% visR::add_CNSR(size = NULL), expected_warning)
+  expect_warning(p %>% visR::add_CNSR(size = NA), expected_warning)
 })
 
-testthat::test_that("T2.4 Warning when NULL or NA are provided as `shape`.", {
+test_that("T2.4 Warning when NULL or NA are provided as `shape`.", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
   expected_warning <- "Invalid `shape` specified. Setting it to 3."
-  testthat::expect_warning(p %>% visR::add_CNSR(shape = NULL), expected_warning)
-  testthat::expect_warning(p %>% visR::add_CNSR(shape = NA), expected_warning)
+  expect_warning(p %>% visR::add_CNSR(shape = NULL), expected_warning)
+  expect_warning(p %>% visR::add_CNSR(shape = NA), expected_warning)
 })
 
-testthat::test_that("T2.5 Warning when a non-atomic string is provided as `shape`.", {
+test_that("T2.5 Warning when a non-atomic string is provided as `shape`.", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
   expected_warning <- "Invalid `shape` specified. If specifiyng a symbol, it must be a single character. Setting it to 3."
-  testthat::expect_warning(p %>% visR::add_CNSR(shape = "visR"), expected_warning)
+  expect_warning(p %>% visR::add_CNSR(shape = "visR"), expected_warning)
 })
 
-testthat::test_that("T2.6 Warning when `shape` is set to a numerical outside of [0-25].", {
+test_that("T2.6 Warning when `shape` is set to a numerical outside of [0-25].", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
 
-  testthat::expect_warning(p %>% visR::add_CNSR(shape = -1))
-  testthat::expect_warning(p %>% visR::add_CNSR(shape = 26))
+  expect_warning(p %>% visR::add_CNSR(shape = -1))
+  expect_warning(p %>% visR::add_CNSR(shape = 26))
 })
 
-testthat::test_that("T2.7 A ggplot warning when a non-matching vector for `size` is specified", {
+test_that("T2.7 A ggplot warning when a non-matching vector for `size` is specified", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
@@ -197,10 +197,10 @@ testthat::test_that("T2.7 A ggplot warning when a non-matching vector for `size`
   abortive_warning <- .check_traceback_stack_for_ggplot_aesthetics_warning()
 
   ggplot_error <- "Aesthetics must be either length 1 or the same as the data"
-  testthat::expect_match(abortive_warning, ggplot_error)
+  expect_match(abortive_warning, ggplot_error)
 })
 
-testthat::test_that("T2.8 A ggplot warning when a non-matching vector for `shape` is specified", {
+test_that("T2.8 A ggplot warning when a non-matching vector for `shape` is specified", {
   p <- adtte %>%
     visR::estimate_KM(strata = "SEX") %>%
     visR::visr()
@@ -212,7 +212,7 @@ testthat::test_that("T2.8 A ggplot warning when a non-matching vector for `shape
   abortive_warning <- .check_traceback_stack_for_ggplot_aesthetics_warning()
 
   ggplot_error <- "Aesthetics must be either length 1 or the same as the data"
-  testthat::expect_match(abortive_warning, ggplot_error)
+  expect_match(abortive_warning, ggplot_error)
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-add_annotation.R
+++ b/tests/testthat/test-add_annotation.R
@@ -31,9 +31,9 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("add_annotation - T1. The function adds annotations to an object of class `ggplot`")
+context("add_annotation - T1. The function adds annotations to an object of class `ggplot`")
 
-testthat::test_that("T1.1 No error when a `ggplot` object is passed to the function in the presence of a label", {
+test_that("T1.1 No error when a `ggplot` object is passed to the function in the presence of a label", {
   visR_KM_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visR::visr()
@@ -42,59 +42,59 @@ testthat::test_that("T1.1 No error when a `ggplot` object is passed to the funct
   visR_cuminc_plot <- visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath") %>%
     visR::visr()
 
-  testthat::expect_error(visR_KM_plot %>% visR::add_annotation(label = "blah"), NA)
-  testthat::expect_error(visR_cuminc_plot %>% visR::add_annotation(label = "blah"), NA)
+  expect_error(visR_KM_plot %>% visR::add_annotation(label = "blah"), NA)
+  expect_error(visR_cuminc_plot %>% visR::add_annotation(label = "blah"), NA)
 })
 
-testthat::test_that("T1.2 An error when a non-`ggplot` object is passed to the function in the presence of a label", {
+test_that("T1.2 An error when a non-`ggplot` object is passed to the function in the presence of a label", {
   visR_plot <- "blah"
 
-  testthat::expect_error(visR::add_annotation(gg = visR_plot, label = "blah"))
+  expect_error(visR::add_annotation(gg = visR_plot, label = "blah"))
 })
 
-testthat::test_that("T1.3 An error when NULL is passed to the function in the presence of a label", {
-  testthat::expect_error(visR::add_annotation(gg = NULL, label = "blah"))
+test_that("T1.3 An error when NULL is passed to the function in the presence of a label", {
+  expect_error(visR::add_annotation(gg = NULL, label = "blah"))
 })
 
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("add_annotation - T2. The function accepts a label of class `character`, `data.frame` or customized objects of class `gtable`")
+context("add_annotation - T2. The function accepts a label of class `character`, `data.frame` or customized objects of class `gtable`")
 
-testthat::test_that("T2.1 An error when a `ggplot` object is passed to the function in the absence of a label", {
+test_that("T2.1 An error when a `ggplot` object is passed to the function in the absence of a label", {
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>% visR::visr()
 
   data <- tidycmprsk::trial
   visR_cuminc_plot <- visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath") %>%
     visR::visr()
 
-  testthat::expect_error(visR::add_annotation(visR_KM_plot, label = NULL))
-  testthat::expect_error(visR::add_annotation(visR_cuminc_plot, label = NULL))
+  expect_error(visR::add_annotation(visR_KM_plot, label = NULL))
+  expect_error(visR::add_annotation(visR_cuminc_plot, label = NULL))
 })
 
-testthat::test_that("T2.2 No error when label is of class `character`", {
+test_that("T2.2 No error when label is of class `character`", {
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>% visR::visr()
 
   data <- tidycmprsk::trial
   visR_cuminc_plot <- visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath") %>%
     visR::visr()
 
-  testthat::expect_error(visR::add_annotation(visR_KM_plot, label = "blah"), NA)
-  testthat::expect_error(visR::add_annotation(visR_cuminc_plot, label = "blah"), NA)
+  expect_error(visR::add_annotation(visR_KM_plot, label = "blah"), NA)
+  expect_error(visR::add_annotation(visR_cuminc_plot, label = "blah"), NA)
 })
 
-testthat::test_that("T2.3 No error when label is of class `data.frame`", {
+test_that("T2.3 No error when label is of class `data.frame`", {
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>% visR::visr()
 
   data <- tidycmprsk::trial
   visR_cuminc_plot <- visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath") %>%
     visR::visr()
 
-  testthat::expect_error(visR::add_annotation(visR_KM_plot, label = adtte[1:5, ]), NA)
-  testthat::expect_error(visR::add_annotation(visR_cuminc_plot, label = adtte[1:5, ]), NA)
+  expect_error(visR::add_annotation(visR_KM_plot, label = adtte[1:5, ]), NA)
+  expect_error(visR::add_annotation(visR_cuminc_plot, label = adtte[1:5, ]), NA)
 })
 
-testthat::test_that("T2.3 No error when label is of class `gtable`", {
+test_that("T2.3 No error when label is of class `gtable`", {
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>% visR::visr()
 
   data <- tidycmprsk::trial
@@ -103,15 +103,15 @@ testthat::test_that("T2.3 No error when label is of class `gtable`", {
 
   lbl <- gridExtra::tableGrob(adtte[1:5, ])
 
-  testthat::expect_error(visR::add_annotation(visR_KM_plot, label = lbl), NA)
-  testthat::expect_error(visR::add_annotation(visR_cuminc_plot, label = lbl), NA)
+  expect_error(visR::add_annotation(visR_KM_plot, label = lbl), NA)
+  expect_error(visR::add_annotation(visR_cuminc_plot, label = lbl), NA)
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("add_annotation - T3. The annotation are representations of the actual label")
+context("add_annotation - T3. The annotation are representations of the actual label")
 
-testthat::test_that("T3.1 An object of type `character` passed to label is not affected by the transformation to an annotation", {
+test_that("T3.1 An object of type `character` passed to label is not affected by the transformation to an annotation", {
   lbl <- "blah"
 
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>%
@@ -123,11 +123,11 @@ testthat::test_that("T3.1 An object of type `character` passed to label is not a
     visR::visr() %>%
     visR::add_annotation(label = lbl)
 
-  testthat::expect_equal(visR_KM_plot$components$grobs[[1]]$label, lbl)
-  testthat::expect_equal(visR_cuminc_plot$components$grobs[[1]]$label, lbl)
+  expect_equal(visR_KM_plot$components$grobs[[1]]$label, lbl)
+  expect_equal(visR_cuminc_plot$components$grobs[[1]]$label, lbl)
 })
 
-testthat::test_that("T3.2 The content of a `data.frame` passed to label is not affected by the transformation to an annotation", {
+test_that("T3.2 The content of a `data.frame` passed to label is not affected by the transformation to an annotation", {
   anno <- adtte[1:6, 1:5]
 
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>%
@@ -175,11 +175,11 @@ testthat::test_that("T3.2 The content of a `data.frame` passed to label is not a
 
   lbl <- data.frame(lapply(anno, as.character), stringsAsFactors = FALSE)
 
-  testthat::expect_equal(d_KM, lbl, check.attributes = FALSE)
-  testthat::expect_equal(d_cuminc, lbl, check.attributes = FALSE)
+  expect_equal(d_KM, lbl, check.attributes = FALSE)
+  expect_equal(d_cuminc, lbl, check.attributes = FALSE)
 })
 
-testthat::test_that("T3.3 The content of a `gtable` passed to label is not affected by the transformation to an annotation", {
+test_that("T3.3 The content of a `gtable` passed to label is not affected by the transformation to an annotation", {
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>% visR::visr()
 
   data <- tidycmprsk::trial
@@ -196,15 +196,15 @@ testthat::test_that("T3.3 The content of a `gtable` passed to label is not affec
 
   gtab <- append(anno, NULL) # Mimic gtable addition to structure
 
-  testthat::expect_equal(gtab, visR_KM_plot$components)
-  testthat::expect_equal(gtab, visR_cuminc_plot$components)
+  expect_equal(gtab, visR_KM_plot$components)
+  expect_equal(gtab, visR_cuminc_plot$components)
 })
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("add_annotation - T4. The annotation can be placed on the plot by specifying the coordinates")
+context("add_annotation - T4. The annotation can be placed on the plot by specifying the coordinates")
 
-testthat::test_that("T4.1 An error when one of the coordinates is not numeric", {
+test_that("T4.1 An error when one of the coordinates is not numeric", {
   lbl <- "blah"
 
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>% visR::visr()
@@ -213,11 +213,11 @@ testthat::test_that("T4.1 An error when one of the coordinates is not numeric", 
   visR_cuminc_plot <- visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath") %>%
     visR::visr()
 
-  testthat::expect_error(visR_KM_plot %>% visR::add_annotation(label = lbl, xmin = "blah"))
-  testthat::expect_error(visR_cuminc_plot %>% visR::add_annotation(label = lbl, xmin = "blah"))
+  expect_error(visR_KM_plot %>% visR::add_annotation(label = lbl, xmin = "blah"))
+  expect_error(visR_cuminc_plot %>% visR::add_annotation(label = lbl, xmin = "blah"))
 })
 
-testthat::test_that("T4.2 The annotation can be moved on the plot by specifying the x coordinates", {
+test_that("T4.2 The annotation can be moved on the plot by specifying the x coordinates", {
   lbl <- "blah"
 
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>%
@@ -237,11 +237,11 @@ testthat::test_that("T4.2 The annotation can be moved on the plot by specifying 
     visR::visr() %>%
     visR::add_annotation(label = lbl)
 
-  testthat::expect_false(isTRUE(all.equal(visR_KM_plot$layers, visR_KM_plot2$layers)))
-  testthat::expect_false(isTRUE(all.equal(visR_cuminc_plot$layers, visR_cuminc_plot2$layers)))
+  expect_false(isTRUE(all.equal(visR_KM_plot$layers, visR_KM_plot2$layers)))
+  expect_false(isTRUE(all.equal(visR_cuminc_plot$layers, visR_cuminc_plot2$layers)))
 })
 
-testthat::test_that("T4.3 The annotation can be moved on the plot by specifying the y coordinates", {
+test_that("T4.3 The annotation can be moved on the plot by specifying the y coordinates", {
   lbl <- "blah"
 
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>%
@@ -261,15 +261,15 @@ testthat::test_that("T4.3 The annotation can be moved on the plot by specifying 
     visR::visr() %>%
     visR::add_annotation(label = lbl)
 
-  testthat::expect_false(isTRUE(all.equal(visR_KM_plot$layers, visR_KM_plot2$layers)))
-  testthat::expect_false(isTRUE(all.equal(visR_cuminc_plot$layers, visR_cuminc_plot2$layers)))
+  expect_false(isTRUE(all.equal(visR_KM_plot$layers, visR_KM_plot2$layers)))
+  expect_false(isTRUE(all.equal(visR_cuminc_plot$layers, visR_cuminc_plot2$layers)))
 })
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("add_annotation - T5. The layout of the annotation can be modified to a certain extend")
+context("add_annotation - T5. The layout of the annotation can be modified to a certain extend")
 
-testthat::test_that("T5.1 The annotation has bold columnheaders when the passed object is of class `data.frame`", {
+test_that("T5.1 The annotation has bold columnheaders when the passed object is of class `data.frame`", {
   anno <- adtte[1:6, 1:5]
 
   visR_KM_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>%
@@ -292,11 +292,11 @@ testthat::test_that("T5.1 The annotation has bold columnheaders when the passed 
   cN_KM <- extracted_lbl_KM[1:length(colnames(anno))]
   cN_cuminc <- extracted_lbl_cuminc[1:length(colnames(anno))]
 
-  testthat::expect_match(unique(sub('\".*\"', "", cN_KM)), "bold()")
-  testthat::expect_match(unique(sub('\".*\"', "", cN_cuminc)), "bold()")
+  expect_match(unique(sub('\".*\"', "", cN_KM)), "bold()")
+  expect_match(unique(sub('\".*\"', "", cN_cuminc)), "bold()")
 })
 
-testthat::test_that("T5.2 The font size can be changed", {
+test_that("T5.2 The font size can be changed", {
   lbl <- "blah"
 
   visR_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>%
@@ -316,11 +316,11 @@ testthat::test_that("T5.2 The font size can be changed", {
     visR::visr() %>%
     visR::add_annotation(label = lbl, base_size = 5)
 
-  testthat::expect_false(isTRUE(all.equal(visR_plot$layers, visR_plot2$layers)))
-  testthat::expect_false(isTRUE(all.equal(visR_cuminc_plot$layers, visR_cuminc_plot2$layers)))
+  expect_false(isTRUE(all.equal(visR_plot$layers, visR_plot2$layers)))
+  expect_false(isTRUE(all.equal(visR_cuminc_plot$layers, visR_cuminc_plot2$layers)))
 })
 
-testthat::test_that("T5.3 The font family can be chosen between 'sans', 'serif' and 'mono'", {
+test_that("T5.3 The font family can be chosen between 'sans', 'serif' and 'mono'", {
   anno <- "blah"
 
   visR_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>% visR::visr()
@@ -329,38 +329,38 @@ testthat::test_that("T5.3 The font family can be chosen between 'sans', 'serif' 
   visR_cuminc_plot <- visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath") %>%
     visR::visr()
 
-  testthat::expect_error(visR_plot %>% visR::add_annotation(
+  expect_error(visR_plot %>% visR::add_annotation(
     label = anno,
     base_family = "sans"
   ), NA)
-  testthat::expect_error(visR_cuminc_plot %>% visR::add_annotation(
+  expect_error(visR_cuminc_plot %>% visR::add_annotation(
     label = anno,
     base_family = "sans"
   ), NA)
 
-  testthat::expect_error(visR_plot %>% visR::add_annotation(
+  expect_error(visR_plot %>% visR::add_annotation(
     label = anno,
     base_family = "serif"
   ), NA)
-  testthat::expect_error(visR_cuminc_plot %>% visR::add_annotation(
+  expect_error(visR_cuminc_plot %>% visR::add_annotation(
     label = anno,
     base_family = "serif"
   ), NA)
 
-  testthat::expect_error(visR_plot %>% visR::add_annotation(
+  expect_error(visR_plot %>% visR::add_annotation(
     label = anno,
     base_family = "mono"
   ), NA)
-  testthat::expect_error(visR_cuminc_plot %>% visR::add_annotation(
+  expect_error(visR_cuminc_plot %>% visR::add_annotation(
     label = anno,
     base_family = "mono"
   ), NA)
 
-  testthat::expect_error(visR_plot %>% visR::add_annotation(
+  expect_error(visR_plot %>% visR::add_annotation(
     label = anno,
     base_family = "blah"
   ))
-  testthat::expect_error(visR_cuminc_plot %>% visR::add_annotation(
+  expect_error(visR_cuminc_plot %>% visR::add_annotation(
     label = anno,
     base_family = "blah"
   ))
@@ -368,9 +368,9 @@ testthat::test_that("T5.3 The font family can be chosen between 'sans', 'serif' 
 
 # Requirement T6 ---------------------------------------------------------------
 
-testthat::context("add_annotation - T6. The output object has an additional attribute `components`")
+context("add_annotation - T6. The output object has an additional attribute `components`")
 
-testthat::test_that("T6.1 The attribute components[['visR_plot']] contains the plot used as input", {
+test_that("T6.1 The attribute components[['visR_plot']] contains the plot used as input", {
   anno <- "blah"
 
   visR_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>% visR::visr()
@@ -381,11 +381,11 @@ testthat::test_that("T6.1 The attribute components[['visR_plot']] contains the p
     visR::visr()
   visR_cuminc_plot_anno <- visR_cuminc_plot %>% visR::add_annotation(label = anno)
 
-  testthat::expect_equal(visR_plot, visR_plot_anno$components$visR_plot)
-  testthat::expect_equal(visR_cuminc_plot, visR_cuminc_plot_anno$components$visR_plot)
+  expect_equal(visR_plot, visR_plot_anno$components$visR_plot)
+  expect_equal(visR_cuminc_plot, visR_cuminc_plot_anno$components$visR_plot)
 })
 
-testthat::test_that("T6.2 The attribute components contains the annotation", {
+test_that("T6.2 The attribute components contains the annotation", {
   anno <- adtte[1:6, 1:5]
 
   visR_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>%
@@ -397,11 +397,11 @@ testthat::test_that("T6.2 The attribute components contains the annotation", {
     visR::visr() %>%
     visR::add_annotation(label = anno)
 
-  testthat::expect_equal(names(visR_plot$components)[[2]], "grobs")
-  testthat::expect_equal(names(visR_cuminc_plot$components)[[2]], "grobs")
+  expect_equal(names(visR_plot$components)[[2]], "grobs")
+  expect_equal(names(visR_cuminc_plot$components)[[2]], "grobs")
 })
 
-testthat::test_that("T6.3 The output has the same class as the original ggplot", {
+test_that("T6.3 The output has the same class as the original ggplot", {
   anno <- adtte[1:6, 1:5]
 
   visR_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>%
@@ -417,8 +417,8 @@ testthat::test_that("T6.3 The output has the same class as the original ggplot",
   visR_cuminc_plot2 <- visR_cuminc_plot %>%
     visR::add_annotation(label = anno)
 
-  testthat::expect_equal(class(visR_plot), class(visR_plot2))
-  testthat::expect_equal(class(visR_cuminc_plot), class(visR_cuminc_plot2))
+  expect_equal(class(visR_plot), class(visR_plot2))
+  expect_equal(class(visR_cuminc_plot), class(visR_cuminc_plot2))
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-add_highlight.R
+++ b/tests/testthat/test-add_highlight.R
@@ -29,88 +29,88 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("add_highlight - T1. The function modifies a `ggsurvfit` object and returns it.")
+context("add_highlight - T1. The function modifies a `ggsurvfit` object and returns it.")
 
-testthat::test_that("T1.1 No error when `add_highlight` is called on a `ggsurvfit` object.", {
+test_that("T1.1 No error when `add_highlight` is called on a `ggsurvfit` object.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
 
-  testthat::expect_true(inherits(gg, "ggsurvfit"))
+  expect_true(inherits(gg, "ggsurvfit"))
 
   gg %>%
     visR::add_highlight(strata = "Placebo") %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T1.2 An error when `add_highlight` is called without a plot.", {
-  visR::add_highlight() %>% testthat::expect_error()
+test_that("T1.2 An error when `add_highlight` is called without a plot.", {
+  visR::add_highlight() %>% expect_error()
 })
 
-testthat::test_that("T1.3 An error when `add_highlight` is called on a non-`ggplot` object", {
+test_that("T1.3 An error when `add_highlight` is called on a non-`ggplot` object", {
   visR::add_highlight(NULL) %>%
-    testthat::expect_error()
+    expect_error()
 
   visR::add_highlight("visR") %>%
-    testthat::expect_error()
+    expect_error()
 
   visR::add_highlight(1) %>%
-    testthat::expect_error()
+    expect_error()
 
   model <- stats::lm(data = adtte, "AGE ~ TRTDUR")
   class(model) <- c(class(model), "ggsurvfit")
 
   visR::add_highlight(model) %>%
-    testthat::expect_error()
+    expect_error()
 })
 
-testthat::test_that("T1.4 An error when `add_highlight` is called on a `ggplot` but non-`ggsurvfit` object.", {
+test_that("T1.4 An error when `add_highlight` is called on a `ggplot` but non-`ggsurvfit` object.", {
   gg <- adtte %>%
     ggplot2::ggplot(ggplot2::aes(x = AGE, y = TRTDUR)) +
     ggplot2::geom_point()
 
-  testthat::expect_true(inherits(gg, "ggplot"))
-  testthat::expect_false(inherits(gg, "ggsurvfit"))
+  expect_true(inherits(gg, "ggplot"))
+  expect_false(inherits(gg, "ggsurvfit"))
 
   gg %>%
     add_highlight() %>%
-    testthat::expect_error()
+    expect_error()
 })
 
-testthat::test_that("T1.5 The function returns a modified object of type `ggsurvfit`.", {
+test_that("T1.5 The function returns a modified object of type `ggsurvfit`.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
 
-  testthat::expect_true(inherits(gg, "ggsurvfit"))
+  expect_true(inherits(gg, "ggsurvfit"))
 
   gg_with_highlight <- gg %>% add_highlight("Placebo")
 
-  testthat::expect_true(inherits(gg_with_highlight, "ggsurvfit"))
+  expect_true(inherits(gg_with_highlight, "ggsurvfit"))
 
-  testthat::expect_false(base::identical(gg, gg_with_highlight))
+  expect_false(base::identical(gg, gg_with_highlight))
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("add_highlight - T2. No errors when one or more strata are highlighted with default parameters.")
+context("add_highlight - T2. No errors when one or more strata are highlighted with default parameters.")
 
-testthat::test_that("T2.1 No error when `strata` is a character string found in the plot strata.", {
+test_that("T2.1 No error when `strata` is a character string found in the plot strata.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
 
   gg %>%
     visR::add_highlight(strata = "Placebo") %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   gg %>%
     visR::add_highlight(strata = "Placebo") %>%
     vdiffr::expect_doppelganger(title = "add_highlight_T2_1_no_error_when_strata_is_string")
 })
 
-testthat::test_that("T2.2 An error when `strata` is a character string not found in the plot strata.", {
+test_that("T2.2 An error when `strata` is a character string not found in the plot strata.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
@@ -119,20 +119,20 @@ testthat::test_that("T2.2 An error when `strata` is a character string not found
 
   gg %>%
     visR::add_highlight(strata = "visR") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T2.3 No error when `strata` is a `list` with a single non-character element.", {
+test_that("T2.3 No error when `strata` is a `list` with a single non-character element.", {
   expected_error <- "A 'strata' must be either a single character string or a list of them."
 
   adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr() %>%
     visR::add_highlight(list(1)) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T2.4 No error when `strata` is a `list` or `vector` of character strings found in the plot strata.", {
+test_that("T2.4 No error when `strata` is a `list` or `vector` of character strings found in the plot strata.", {
   strata_list <- list("Placebo", "Xanomeline Low Dose")
   strata_vector <- c("Placebo", "Xanomeline Low Dose")
 
@@ -142,13 +142,13 @@ testthat::test_that("T2.4 No error when `strata` is a `list` or `vector` of char
 
   gg %>%
     visR::add_highlight(strata = strata_list) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   gg %>%
     visR::add_highlight(strata = strata_vector) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
 
   gg %>%
     visR::add_highlight(strata = strata_list) %>%
@@ -159,7 +159,7 @@ testthat::test_that("T2.4 No error when `strata` is a `list` or `vector` of char
     vdiffr::expect_doppelganger(title = "add_highlight_T2_4_no_error_when_strata_is_string_vec") # 'vector' shortened because of tarball size
 })
 
-testthat::test_that("T2.5 An error when `strata` is a `list` or `vector` that holds non-character-string elements.", {
+test_that("T2.5 An error when `strata` is a `list` or `vector` that holds non-character-string elements.", {
   strata <- c(1, 2, 3)
 
   gg <- adtte %>%
@@ -170,10 +170,10 @@ testthat::test_that("T2.5 An error when `strata` is a `list` or `vector` that ho
 
   gg %>%
     visR::add_highlight(strata = strata) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T2.6 An error when `strata` is not a character string or a list.", {
+test_that("T2.6 An error when `strata` is not a character string or a list.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
@@ -182,28 +182,28 @@ testthat::test_that("T2.6 An error when `strata` is not a character string or a 
 
   gg %>%
     visR::add_highlight(strata = NA) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 
   gg %>%
     visR::add_highlight(strata = 1) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T2.7 An error when `strata` is `NULL` or missing.", {
+test_that("T2.7 An error when `strata` is `NULL` or missing.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
 
   gg %>%
     visR::add_highlight(strata = NULL) %>%
-    testthat::expect_error()
+    expect_error()
 
   gg %>%
     visR::add_highlight() %>%
-    testthat::expect_error()
+    expect_error()
 })
 
-testthat::test_that("T2.8 An error when `strata` is not a character string or a list.", {
+test_that("T2.8 An error when `strata` is not a character string or a list.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
@@ -212,18 +212,18 @@ testthat::test_that("T2.8 An error when `strata` is not a character string or a 
 
   gg %>%
     visR::add_highlight(strata = NA) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 
   gg %>%
     visR::add_highlight(strata = 1) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("add_highlight - T3. The opacity of the background strata can be changed through `bg_alpha`.")
+context("add_highlight - T3. The opacity of the background strata can be changed through `bg_alpha`.")
 
-testthat::test_that("T3.1 No error when `bg_alpha` is a `numberic`.", {
+test_that("T3.1 No error when `bg_alpha` is a `numberic`.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
@@ -233,10 +233,10 @@ testthat::test_that("T3.1 No error when `bg_alpha` is a `numberic`.", {
       strata = "Placebo",
       bg_alpha = 0.2
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T3.2 An error when `bg_alpha` is a not a `numberic`.", {
+test_that("T3.2 An error when `bg_alpha` is a not a `numberic`.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
@@ -248,10 +248,10 @@ testthat::test_that("T3.2 An error when `bg_alpha` is a not a `numberic`.", {
       strata = "Placebo",
       bg_alpha = "visR"
     ) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T3.3 An error when `bg_alpha` is outside of [0, 1].", {
+test_that("T3.3 An error when `bg_alpha` is outside of [0, 1].", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
@@ -263,22 +263,22 @@ testthat::test_that("T3.3 An error when `bg_alpha` is outside of [0, 1].", {
       strata = "Placebo",
       bg_alpha = -1
     ) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 
   gg %>%
     visR::add_highlight(
       strata = "Placebo",
       bg_alpha = 2
     ) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T3.4 The alpha of the background strata changes with `bg_alpha`.", {
+test_that("T3.4 The alpha of the background strata changes with `bg_alpha`.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
 
-  testthat::skip_on_cran()
+  skip_on_cran()
 
   gg %>%
     visR::add_highlight(
@@ -304,9 +304,9 @@ testthat::test_that("T3.4 The alpha of the background strata changes with `bg_al
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("add_highlight - T4. The function modifies the underlying data structure than is interpreted during plotting.")
+context("add_highlight - T4. The function modifies the underlying data structure than is interpreted during plotting.")
 
-testthat::test_that("T4.1 The function adds the alpha channel to the hex-encoded colour.", {
+test_that("T4.1 The function adds the alpha channel to the hex-encoded colour.", {
   gg <- adtte %>%
     visR::estimate_KM(strata = "TRTP") %>%
     visR::visr()
@@ -324,10 +324,10 @@ testthat::test_that("T4.1 The function adds the alpha channel to the hex-encoded
     gsub(c, "", gg_with_highlight_colours[gg_colours == c])
   }))
 
-  testthat::expect_identical(alphas, c("FF", "33", "33"))
+  expect_identical(alphas, c("FF", "33", "33"))
 })
 
-testthat::test_that("T4.2 The function also reduces the alpha value of the confidence intervals introduced by `add_CI`.", {
+test_that("T4.2 The function also reduces the alpha value of the confidence intervals introduced by `add_CI`.", {
   ci_alpha <- 0.5
   bg_alpha <- 0.2
 
@@ -362,16 +362,16 @@ testthat::test_that("T4.2 The function also reduces the alpha value of the confi
     }) %>%
     as.vector()
 
-  testthat::expect_equal(
+  expect_equal(
     gg_CI_fills_numeric,
     rep(ci_alpha, length(gg_CI_fills_numeric))
   )
 
   # To not over-engineer the test here, we take for granted that the foreground
   # strata is the first of the three in the evaluation order
-  testthat::expect_equal(gg_with_highlight_CI_fills_numeric[1], ci_alpha)
-  testthat::expect_equal(gg_with_highlight_CI_fills_numeric[2], ci_alpha * bg_alpha)
-  testthat::expect_equal(gg_with_highlight_CI_fills_numeric[3], ci_alpha * bg_alpha)
+  expect_equal(gg_with_highlight_CI_fills_numeric[1], ci_alpha)
+  expect_equal(gg_with_highlight_CI_fills_numeric[2], ci_alpha * bg_alpha)
+  expect_equal(gg_with_highlight_CI_fills_numeric[3], ci_alpha * bg_alpha)
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-add_quantiles.R
+++ b/tests/testthat/test-add_quantiles.R
@@ -23,28 +23,28 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("add_quantiles - T1. The quantile lines are y-axis-transformation dependent.")
+context("add_quantiles - T1. The quantile lines are y-axis-transformation dependent.")
 
-testthat::test_that("T1.1 No error when the default `surv` option is used.", {
+test_that("T1.1 No error when the default `surv` option is used.", {
   adtte %>%
     visR::estimate_KM() %>%
     visR::visr() %>% # defaults to fun = "surv"
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T1.2 No error when a function is passed as a string.", {
+test_that("T1.2 No error when a function is passed as a string.", {
   adtte %>%
     visR::estimate_KM() %>%
     visR::visr(fun = "log") %>%
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::estimate_KM() %>%
     visR::visr(fun = "event") %>%
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   suppressWarnings(
     adtte %>%
@@ -52,36 +52,36 @@ testthat::test_that("T1.2 No error when a function is passed as a string.", {
       visR::visr(fun = "cloglog")
   ) %>%
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::estimate_KM() %>%
     visR::visr(fun = "pct") %>%
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::estimate_KM() %>%
     visR::visr(fun = "logpct") %>%
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::estimate_KM() %>%
     visR::visr(fun = "cumhaz") %>%
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T1.3 No error when a `.Primitive` function is used.", {
+test_that("T1.3 No error when a `.Primitive` function is used.", {
   adtte %>%
     visR::estimate_KM() %>%
     visR::visr(fun = log, y_label = "neded_since_fun_not_string") %>%
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T1.4 No error when a custom function is used.", {
+test_that("T1.4 No error when a custom function is used.", {
   suppressWarnings(
     adtte %>%
       visR::estimate_KM() %>%
@@ -91,14 +91,14 @@ testthat::test_that("T1.4 No error when a custom function is used.", {
       )
   ) %>%
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("add_quantiles - T2. If any parameter is specified incorrectly, defaults are used instead.")
+context("add_quantiles - T2. If any parameter is specified incorrectly, defaults are used instead.")
 
-testthat::test_that("T2.1 A warning if `quantiles` is not a numeric or vector of numerics.", {
+test_that("T2.1 A warning if `quantiles` is not a numeric or vector of numerics.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
@@ -107,18 +107,18 @@ testthat::test_that("T2.1 A warning if `quantiles` is not a numeric or vector of
 
   gg %>%
     visR::add_quantiles(quantiles = NULL) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 
   gg %>%
     visR::add_quantiles(quantiles = "visR") %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 
   gg %>%
     visR::add_quantiles(quantiles = c(0.2, "visR", 0.5)) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 })
 
-testthat::test_that("T2.2 A warning if `linetype` is not a character string.", {
+test_that("T2.2 A warning if `linetype` is not a character string.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
@@ -127,14 +127,14 @@ testthat::test_that("T2.2 A warning if `linetype` is not a character string.", {
 
   gg %>%
     visR::add_quantiles(linetype = NULL) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 
   gg %>%
     visR::add_quantiles(linetype = 1) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 })
 
-testthat::test_that("T2.3 A warning if `linecolour` is not a character string.", {
+test_that("T2.3 A warning if `linecolour` is not a character string.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
@@ -143,14 +143,14 @@ testthat::test_that("T2.3 A warning if `linecolour` is not a character string.",
 
   gg %>%
     visR::add_quantiles(linecolour = NULL) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 
   gg %>%
     visR::add_quantiles(linecolour = 1) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 })
 
-testthat::test_that("T2.4 A warning if `alpha` is not a character string or outside [0, 1].", {
+test_that("T2.4 A warning if `alpha` is not a character string or outside [0, 1].", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
@@ -159,49 +159,49 @@ testthat::test_that("T2.4 A warning if `alpha` is not a character string or outs
 
   gg %>%
     visR::add_quantiles(alpha = "visR") %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 
   gg %>%
     visR::add_quantiles(alpha = -1) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 
   gg %>%
     visR::add_quantiles(alpha = 10) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 })
 
 
-testthat::test_that("T2.5 No error when the default parameters are used.", {
+test_that("T2.5 No error when the default parameters are used.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
 
   gg %>%
     visR::add_quantiles() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.6 No error when `quantiles` is a single number.", {
+test_that("T2.6 No error when `quantiles` is a single number.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
 
   gg %>%
     visR::add_quantiles(quantiles = 0.5) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.7 No error when `quantiles` is a numeric vector.", {
+test_that("T2.7 No error when `quantiles` is a numeric vector.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
 
   gg %>%
     visR::add_quantiles(quantiles = c(0.25, 0.50)) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.8 No error when `linetype` is a non-default character string.", {
+test_that("T2.8 No error when `linetype` is a non-default character string.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
@@ -211,10 +211,10 @@ testthat::test_that("T2.8 No error when `linetype` is a non-default character st
       quantiles = c(0.25, 0.50),
       linetype = "solid"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.9 No error when `linetype` is `mixed`.", {
+test_that("T2.9 No error when `linetype` is `mixed`.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
@@ -224,10 +224,10 @@ testthat::test_that("T2.9 No error when `linetype` is `mixed`.", {
       quantiles = c(0.25, 0.50),
       linetype = "mixed"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.10 No error when `linecolour` is a non-default character string.", {
+test_that("T2.10 No error when `linecolour` is a non-default character string.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
@@ -238,10 +238,10 @@ testthat::test_that("T2.10 No error when `linecolour` is a non-default character
       linetype = "solid",
       linecolour = "red"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.11 No error when `linecolour` is `strata`.", {
+test_that("T2.11 No error when `linecolour` is `strata`.", {
   gg <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr()
@@ -252,7 +252,7 @@ testthat::test_that("T2.11 No error when `linecolour` is `strata`.", {
       linetype = "solid",
       linecolour = "strata"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-add_risktable.R
+++ b/tests/testthat/test-add_risktable.R
@@ -26,39 +26,39 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("add_risktable.survfit - T1. The function accepts a `ggsurvfit` object.")
+context("add_risktable.survfit - T1. The function accepts a `ggsurvfit` object.")
 
-testthat::test_that("T1.1 No error when a `ggsurvfit` object is passed to the function.", {
+test_that("T1.1 No error when a `ggsurvfit` object is passed to the function.", {
   visR_plot <- visR::estimate_KM(data = adtte, strata = "TRTA") %>% visR::visr()
-  testthat::expect_error(visR::add_risktable(visR_plot), NA)
+  expect_error(visR::add_risktable(visR_plot), NA)
 
   visR_plot <-
     visR::estimate_cuminc(tidycmprsk::trial, AVAL = "ttdeath", CNSR = "death_cr") %>%
     visR::visr(x_units = "Months")
-  testthat::expect_error(visR::add_risktable(visR_plot), NA)
+  expect_error(visR::add_risktable(visR_plot), NA)
 })
 
-testthat::test_that("T1.2 An error when a non-`ggsurvfit` object is passed to the function.", {
+test_that("T1.2 An error when a non-`ggsurvfit` object is passed to the function.", {
   survfit_object <- visR::estimate_KM(data = adtte, strata = "TRTA")
 
-  testthat::expect_error(visR::add_risktable(survfit_object))
+  expect_error(visR::add_risktable(survfit_object))
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("add_risktable.survfit - T2. The risktables are `ggplot` representations of the actual risktables.")
+context("add_risktable.survfit - T2. The risktables are `ggplot` representations of the actual risktables.")
 
-testthat::test_that("T2.1 When no strata were specified, an artificial strata is displayed 'Overall'.", {
+test_that("T2.1 When no strata were specified, an artificial strata is displayed 'Overall'.", {
   visR_plot <- adtte %>%
     visR::estimate_KM() %>%
     visR::visr() %>%
     visR::add_risktable()
   strata <- base::intersect("Overall", names(visR_plot$components))
 
-  testthat::expect_error(strata == "Overall", NA)
+  expect_error(strata == "Overall", NA)
 })
 
-testthat::test_that("T2.2 The calculated values in the risktable are not affected by the transformation to a `ggplot`.", {
+test_that("T2.2 The calculated values in the risktable are not affected by the transformation to a `ggplot`.", {
   visR_risk <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visR::get_risktable()
@@ -69,46 +69,46 @@ testthat::test_that("T2.2 The calculated values in the risktable are not affecte
 
   plot_risk <- visR_plot$components$Placebo$data
 
-  testthat::expect_equal(visR_risk, plot_risk, check.attributes = FALSE)
+  expect_equal(visR_risk, plot_risk, check.attributes = FALSE)
 })
 
-testthat::test_that("T2.3 The risktables are placed below the visR plot, in alignment with the x-axis of a visR plot without legend.", {
+test_that("T2.3 The risktables are placed below the visR plot, in alignment with the x-axis of a visR plot without legend.", {
   visR_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visR::visr() +
     ggplot2::theme(legend.position = "none")
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   visR_plot %>%
     visR::add_risktable() %>%
     vdiffr::expect_doppelganger(title = "add_risktable_T2_3_aligned_when_no_legend")
 })
 
-testthat::test_that("T2.4 The risktables are placed below the visR plot, in alignment with the x-axis of a visR plot without legend.", {
+test_that("T2.4 The risktables are placed below the visR plot, in alignment with the x-axis of a visR plot without legend.", {
   visR_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visR::visr() %>%
     visR::add_risktable()
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   visR_plot %>%
     vdiffr::expect_doppelganger(title = "add_risktable_T2_4_aligned_when_legend")
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("add_risktable.survfit - T3. The output object is ggplot with additional class `ggsurvfit` and attribute `components`.")
+context("add_risktable.survfit - T3. The output object is ggplot with additional class `ggsurvfit` and attribute `components`.")
 
-testthat::test_that("T3.1 The output object has an additional attribute `components`.", {
+test_that("T3.1 The output object has an additional attribute `components`.", {
   visR_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visR::visr() %>%
     visR::add_risktable()
 
-  testthat::expect_true("components" %in% names(visR_plot))
+  expect_true("components" %in% names(visR_plot))
 })
 
-testthat::test_that("T3.2 The attribute components[['visR_plot']] contains the plot used as input.", {
+test_that("T3.2 The attribute components[['visR_plot']] contains the plot used as input.", {
   visR_plot_base <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visR::visr()
@@ -116,10 +116,10 @@ testthat::test_that("T3.2 The attribute components[['visR_plot']] contains the p
   visR_plot <- visR_plot_base %>%
     visR::add_risktable()
 
-  testthat::expect_equal(visR_plot_base, visR_plot$components$visR_plot)
+  expect_equal(visR_plot_base, visR_plot$components$visR_plot)
 })
 
-testthat::test_that("T3.3 The attribute components contains the risktables, identified through the risktable titles.", {
+test_that("T3.3 The attribute components contains the risktables, identified through the risktable titles.", {
   visR_plot_base <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visR::visr()
@@ -131,20 +131,20 @@ testthat::test_that("T3.3 The attribute components contains the risktables, iden
     visR::estimate_KM(strata = "TRTA") %>%
     visR::get_risktable()
 
-  testthat::expect_equal(visR_plot$components$Placebo$data,
+  expect_equal(visR_plot$components$Placebo$data,
     risktable1,
     check.attributes = FALSE
   )
 
   risknames <- names(visR_plot$components)[2:4]
-  testthat::expect_equal(risknames, c(
+  expect_equal(risknames, c(
     "Placebo",
     "Xanomeline High Dose",
     "Xanomeline Low Dose"
   ))
 })
 
-testthat::test_that("T3.4 The output has class `ggsurvfit`.", {
+test_that("T3.4 The output has class `ggsurvfit`.", {
   visR_plot_base <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visR::visr()
@@ -152,66 +152,66 @@ testthat::test_that("T3.4 The output has class `ggsurvfit`.", {
   visR_plot <- visR_plot_base %>%
     visR::add_risktable()
 
-  testthat::expect_true(inherits(visR_plot, "ggsurvfit"))
+  expect_true(inherits(visR_plot, "ggsurvfit"))
 })
 
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("add_risktable.survfit - T4. The function accepts a numeric rowgutter value")
+context("add_risktable.survfit - T4. The function accepts a numeric rowgutter value")
 
-testthat::test_that("T4.1 An error when the rowgutter is not numeric", {
+test_that("T4.1 An error when the rowgutter is not numeric", {
   visR_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visr()
 
-  testthat::expect_error(visR::add_risktable(visR_plot, rowgutter = "blah"))
+  expect_error(visR::add_risktable(visR_plot, rowgutter = "blah"))
 })
 
-testthat::test_that("T4.2 An error when the rowgutter is negative", {
+test_that("T4.2 An error when the rowgutter is negative", {
   visR_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visr()
 
-  testthat::expect_error(visR::add_risktable(visR_plot, rowgutter = -0.001))
+  expect_error(visR::add_risktable(visR_plot, rowgutter = -0.001))
 })
 
-testthat::test_that("T4.3 An error when the rowgutter is larger than 1", {
+test_that("T4.3 An error when the rowgutter is larger than 1", {
   visR_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visr()
 
-  testthat::expect_error(visR::add_risktable(visR_plot, rowgutter = 1.001))
+  expect_error(visR::add_risktable(visR_plot, rowgutter = 1.001))
 })
 
-testthat::test_that("T4.4 No error when the rowgutter is numeric between 0 and 1", {
+test_that("T4.4 No error when the rowgutter is numeric between 0 and 1", {
   visR_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visr()
 
-  testthat::expect_error(visR::add_risktable(visR_plot, rowgutter = 0.2), NA)
+  expect_error(visR::add_risktable(visR_plot, rowgutter = 0.2), NA)
 })
 
 
 
-testthat::test_that("T4.5 No error when the default rowgutter is used", {
+test_that("T4.5 No error when the default rowgutter is used", {
   visR_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visr()
 
-  testthat::expect_error(visR::add_risktable(visR_plot), NA)
+  expect_error(visR::add_risktable(visR_plot), NA)
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   visR::add_risktable(visR_plot) %>%
     vdiffr::expect_doppelganger(title = "T4.No_error_when_the_default_rowgutter_is_used")
 })
 
-testthat::test_that("T4.6 Changing rowgutter affects on the heights of the table and plot", {
+test_that("T4.6 Changing rowgutter affects on the heights of the table and plot", {
   visR_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visr()
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   visR::add_risktable(visR_plot, rowgutter = 0.3) %>%
     vdiffr::expect_doppelganger(title = "T4.6_Changing_rowgutter_affects_on_the_heights_of_the_table_and_plot")
 })

--- a/tests/testthat/test-apply_attrition.R
+++ b/tests/testthat/test-apply_attrition.R
@@ -29,19 +29,19 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("apply_attrition - T1. The function accepts a `data.frame` `tibble` or `data.table`")
+context("apply_attrition - T1. The function accepts a `data.frame` `tibble` or `data.table`")
 
-testthat::test_that("T1.1. No error when `data` is of class `data.frame`", {
+test_that("T1.1. No error when `data` is of class `data.frame`", {
   data <- adtte
-  testthat::expect_error(
+  expect_error(
     visR::apply_attrition(data, c("TRTP == 'Placebo'", "AGE >= 75")), NA
   )
 })
 
 
-testthat::test_that("T1.2. No error when `data` is of class `tibble`", {
+test_that("T1.2. No error when `data` is of class `tibble`", {
   data <- dplyr::as_tibble(adtte)
-  testthat::expect_error(
+  expect_error(
     visR::apply_attrition(
       data,
       criteria_conditions = c("TRTP == 'Placebo'", "AGE >= 75")
@@ -49,10 +49,10 @@ testthat::test_that("T1.2. No error when `data` is of class `tibble`", {
   )
 })
 
-testthat::test_that("T1.3. No error when `data` is of class `data.table`", {
+test_that("T1.3. No error when `data` is of class `data.table`", {
   if (nzchar(find.package("data.table"))) {
     data <- data.table::as.data.table(adtte)
-    testthat::expect_error(
+    expect_error(
       visR::apply_attrition(
         data,
         criteria_conditions = c("TRTP == 'Placebo'", "AGE >= 75")
@@ -61,9 +61,9 @@ testthat::test_that("T1.3. No error when `data` is of class `data.table`", {
   }
 })
 
-testthat::test_that("T1.4. An error when `data` is of class `list`", {
+test_that("T1.4. An error when `data` is of class `list`", {
   data <- base::as.list(adtte)
-  testthat::expect_error(
+  expect_error(
     visR::apply_attrition(
       data,
       criteria_conditions = c("TRTP == 'Placebo'", "AGE >= 75")
@@ -71,8 +71,8 @@ testthat::test_that("T1.4. An error when `data` is of class `list`", {
   )
 })
 
-testthat::test_that("T1.5 An error when `data` is NULL", {
-  testthat::expect_error(
+test_that("T1.5 An error when `data` is NULL", {
+  expect_error(
     visR::apply_attrition(
       NULL,
       criteria_conditions = c("TRTP == 'Placebo'", "AGE >= 75")
@@ -80,8 +80,8 @@ testthat::test_that("T1.5 An error when `data` is NULL", {
   )
 })
 
-testthat::test_that("T1.6 An error when `data` is NA", {
-  testthat::expect_error(
+test_that("T1.6 An error when `data` is NA", {
+  expect_error(
     visR::apply_attrition(
       NA,
       criteria_conditions = c("TRTP == 'Placebo'", "AGE >= 75")
@@ -89,8 +89,8 @@ testthat::test_that("T1.6 An error when `data` is NA", {
   )
 })
 
-testthat::test_that("T1.7 An error when `data` does not exist in the global environment", {
-  testthat::expect_error(
+test_that("T1.7 An error when `data` does not exist in the global environment", {
+  expect_error(
     visR::apply_attrition(
       blah,
       criteria_conditions = c("TRTP == 'Placebo'", "AGE >= 75")
@@ -100,10 +100,10 @@ testthat::test_that("T1.7 An error when `data` does not exist in the global envi
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("apply_attrition - T2. The function correctly handles arguments")
+context("apply_attrition - T2. The function correctly handles arguments")
 
-testthat::test_that("T2.1 No error when `criteria_conditions` is a character vector", {
-  testthat::expect_error(
+test_that("T2.1 No error when `criteria_conditions` is a character vector", {
+  expect_error(
     visR::apply_attrition(
       adtte,
       criteria_conditions = c("TRTP == 'Placebo'", "AGE >= 75")
@@ -111,8 +111,8 @@ testthat::test_that("T2.1 No error when `criteria_conditions` is a character vec
   )
 })
 
-testthat::test_that("T2.2 An error when `criteria_conditions` is not a character vector", {
-  testthat::expect_error(
+test_that("T2.2 An error when `criteria_conditions` is not a character vector", {
+  expect_error(
     visR::apply_attrition(
       adtte,
       criteria_conditions = 123
@@ -120,8 +120,8 @@ testthat::test_that("T2.2 An error when `criteria_conditions` is not a character
   )
 })
 
-testthat::test_that("T2.3 An error when `criteria_conditions` is NULL", {
-  testthat::expect_error(
+test_that("T2.3 An error when `criteria_conditions` is NULL", {
+  expect_error(
     visR::apply_attrition(
       adtte,
       criteria_conditions = NULL
@@ -129,22 +129,22 @@ testthat::test_that("T2.3 An error when `criteria_conditions` is NULL", {
   )
 })
 
-testthat::test_that("T2.4 An error when `data` is missing.", {
-  testthat::expect_error(
+test_that("T2.4 An error when `data` is missing.", {
+  expect_error(
     visR::apply_attrition(criteria_conditions = NULL)
   )
 })
 
-testthat::test_that("T2.5 An error when `criteria_conditions` is missing.", {
-  testthat::expect_error(visR::apply_attrition(data = adtte))
+test_that("T2.5 An error when `criteria_conditions` is missing.", {
+  expect_error(visR::apply_attrition(data = adtte))
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("apply_attrition - T3. The function filters correctly when provided a vector of single filters")
+context("apply_attrition - T3. The function filters correctly when provided a vector of single filters")
 
-testthat::test_that("T3.1 Correct filtering string column", {
-  testthat::expect_equal(
+test_that("T3.1 Correct filtering string column", {
+  expect_equal(
     visR::apply_attrition(
       adtte,
       criteria_conditions = c("TRTP == 'Placebo'")
@@ -152,8 +152,8 @@ testthat::test_that("T3.1 Correct filtering string column", {
   )
 })
 
-testthat::test_that("T3.2 Correct filtering integer column", {
-  testthat::expect_equal(
+test_that("T3.2 Correct filtering integer column", {
+  expect_equal(
     visR::apply_attrition(
       adtte,
       criteria_conditions = c("AGE >= 75")
@@ -161,9 +161,9 @@ testthat::test_that("T3.2 Correct filtering integer column", {
   )
 })
 
-testthat::test_that("T3.3 Correct filtering factor column", {
+test_that("T3.3 Correct filtering factor column", {
   data <- adtte %>% dplyr::mutate(AGEGR1 = factor(AGEGR1))
-  testthat::expect_equal(
+  expect_equal(
     visR::apply_attrition(
       data,
       criteria_conditions = c("AGEGR1 == '< 65'")
@@ -173,10 +173,10 @@ testthat::test_that("T3.3 Correct filtering factor column", {
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("apply_attrition - T4. The function filters correctly when provided a vector of combined filters")
+context("apply_attrition - T4. The function filters correctly when provided a vector of combined filters")
 
-testthat::test_that("T4.1 Correct filtering using a combined filter containing logical `and` (`&`)", {
-  testthat::expect_equal(
+test_that("T4.1 Correct filtering using a combined filter containing logical `and` (`&`)", {
+  expect_equal(
     visR::apply_attrition(
       adtte,
       criteria_conditions = c("AGEGR1 == '< 65' & SEX == 'M'")
@@ -185,7 +185,7 @@ testthat::test_that("T4.1 Correct filtering using a combined filter containing l
       dplyr::filter(SEX == "M")
   )
 
-  testthat::expect_equal(
+  expect_equal(
     visR::apply_attrition(
       adtte,
       criteria_conditions = c(
@@ -200,8 +200,8 @@ testthat::test_that("T4.1 Correct filtering using a combined filter containing l
 })
 
 #
-testthat::test_that("T4.2 Correct filtering using a combined filter containing logical `or` (`|`)", {
-  testthat::expect_equal(
+test_that("T4.2 Correct filtering using a combined filter containing logical `or` (`|`)", {
+  expect_equal(
     visR::apply_attrition(
       adtte,
       criteria_conditions = c("AGEGR1 == '< 65' | SEX == 'M'")
@@ -209,7 +209,7 @@ testthat::test_that("T4.2 Correct filtering using a combined filter containing l
       dplyr::filter(AGEGR1 == "< 65" | SEX == "M")
   )
 
-  testthat::expect_equal(
+  expect_equal(
     visR::apply_attrition(
       adtte,
       criteria_conditions = c(
@@ -221,7 +221,7 @@ testthat::test_that("T4.2 Correct filtering using a combined filter containing l
       dplyr::filter(TRTP == "Placebo")
   )
 
-  testthat::expect_equal(
+  expect_equal(
     visR::apply_attrition(
       adtte,
       criteria_conditions = c(
@@ -238,15 +238,15 @@ testthat::test_that("T4.2 Correct filtering using a combined filter containing l
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("apply_attrition - T5. The returned object is of correct class")
+context("apply_attrition - T5. The returned object is of correct class")
 
-testthat::test_that("T5.1 The object is of class `data.frame`", {
+test_that("T5.1 The object is of class `data.frame`", {
   outdf <- visR::apply_attrition(
     adtte,
     criteria_conditions = c("TRTP == 'Placebo'", "AGE >= 75")
   )
 
-  testthat::expect_s3_class(outdf, "data.frame")
+  expect_s3_class(outdf, "data.frame")
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-apply_theme.R
+++ b/tests/testthat/test-apply_theme.R
@@ -27,28 +27,28 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("apply_theme - T1. The function applies the specified changes to a `ggplot` object.")
+context("apply_theme - T1. The function applies the specified changes to a `ggplot` object.")
 
-testthat::test_that("T1.1 No error when a `ggplot` plot is provided, but no theme.", {
+test_that("T1.1 No error when a `ggplot` plot is provided, but no theme.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
 
-  testthat::expect_error(visR::apply_theme(gg), NA)
+  expect_error(visR::apply_theme(gg), NA)
 })
 
-testthat::test_that("T1.2 No error when a `ggplot` plot and a minimal `visR::define_theme` object are provided.", {
+test_that("T1.2 No error when a `ggplot` plot and a minimal `visR::define_theme` object are provided.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
 
   theme <- visR::define_theme()
 
-  testthat::expect_error(visR::apply_theme(gg, theme), NA)
-  testthat::expect_error(gg %>% visR::apply_theme(theme), NA)
+  expect_error(visR::apply_theme(gg, theme), NA)
+  expect_error(gg %>% visR::apply_theme(theme), NA)
 })
 
-testthat::test_that("T1.3 No error when a `ggplot` plot and a complex `visR::define_theme` object are provided.", {
+test_that("T1.3 No error when a `ggplot` plot and a complex `visR::define_theme` object are provided.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -74,25 +74,25 @@ testthat::test_that("T1.3 No error when a `ggplot` plot and a complex `visR::def
     bg = "transparent"
   )
 
-  testthat::expect_error(visR::apply_theme(gg, theme), NA)
-  testthat::expect_error(gg %>% visR::apply_theme(theme), NA)
+  expect_error(visR::apply_theme(gg, theme), NA)
+  expect_error(gg %>% visR::apply_theme(theme), NA)
 })
 
-testthat::test_that("T1.4 A message when a theme not generated through `visR::define_theme` is provided.", {
+test_that("T1.4 A message when a theme not generated through `visR::define_theme` is provided.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
 
   theme <- list("fontfamily" = "Palatino")
 
-  testthat::expect_error(visR::apply_theme(gg, theme), NA)
-  testthat::expect_error(gg %>% visR::apply_theme(theme), NA)
+  expect_error(visR::apply_theme(gg, theme), NA)
+  expect_error(gg %>% visR::apply_theme(theme), NA)
 
-  testthat::expect_message(visR::apply_theme(gg, theme))
-  testthat::expect_message(gg %>% visR::apply_theme(theme))
+  expect_message(visR::apply_theme(gg, theme))
+  expect_message(gg %>% visR::apply_theme(theme))
 })
 
-testthat::test_that("T1.5 If `fontsizes` is a `numeric`, the other font occurrences are derived from it.", {
+test_that("T1.5 If `fontsizes` is a `numeric`, the other font occurrences are derived from it.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -102,14 +102,14 @@ testthat::test_that("T1.5 If `fontsizes` is a `numeric`, the other font occurren
   gg <- gg %>% visR::apply_theme(theme)
   ggb <- ggplot2::ggplot_build(gg)
 
-  testthat::expect_equal(theme$fontsizes, ggb$plot$theme$axis.title.x$size)
-  testthat::expect_equal(theme$fontsizes, ggb$plot$theme$axis.title.y$size)
-  testthat::expect_equal(theme$fontsizes, ggb$plot$theme$axis.text$size)
-  testthat::expect_equal(theme$fontsizes, ggb$plot$theme$legend.title$size)
-  testthat::expect_equal(theme$fontsizes, ggb$plot$theme$legend.text$size)
+  expect_equal(theme$fontsizes, ggb$plot$theme$axis.title.x$size)
+  expect_equal(theme$fontsizes, ggb$plot$theme$axis.title.y$size)
+  expect_equal(theme$fontsizes, ggb$plot$theme$axis.text$size)
+  expect_equal(theme$fontsizes, ggb$plot$theme$legend.title$size)
+  expect_equal(theme$fontsizes, ggb$plot$theme$legend.text$size)
 })
 
-testthat::test_that("T1.6 If `fontsizes` is a `list`, the individual fonts are extracted and used.", {
+test_that("T1.6 If `fontsizes` is a `list`, the individual fonts are extracted and used.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -124,14 +124,14 @@ testthat::test_that("T1.6 If `fontsizes` is a `list`, the individual fonts are e
   gg <- gg %>% visR::apply_theme(theme)
   ggb <- ggplot2::ggplot_build(gg)
 
-  testthat::expect_equal(theme$fontsizes$axis, ggb$plot$theme$axis.title.x$size)
-  testthat::expect_equal(theme$fontsizes$axis, ggb$plot$theme$axis.title.y$size)
-  testthat::expect_equal(theme$fontsizes$ticks, ggb$plot$theme$axis.text$size)
-  testthat::expect_equal(theme$fontsizes$legend_title, ggb$plot$theme$legend.title$size)
-  testthat::expect_equal(theme$fontsizes$legend_text, ggb$plot$theme$legend.text$size)
+  expect_equal(theme$fontsizes$axis, ggb$plot$theme$axis.title.x$size)
+  expect_equal(theme$fontsizes$axis, ggb$plot$theme$axis.title.y$size)
+  expect_equal(theme$fontsizes$ticks, ggb$plot$theme$axis.text$size)
+  expect_equal(theme$fontsizes$legend_title, ggb$plot$theme$legend.title$size)
+  expect_equal(theme$fontsizes$legend_text, ggb$plot$theme$legend.text$size)
 })
 
-testthat::test_that("T1.7 The fontfamily applied through `visR::apply_theme()` is used in the resulting `ggplot` object.", {
+test_that("T1.7 The fontfamily applied through `visR::apply_theme()` is used in the resulting `ggplot` object.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -141,10 +141,10 @@ testthat::test_that("T1.7 The fontfamily applied through `visR::apply_theme()` i
   gg <- gg %>% visR::apply_theme(theme)
   ggb <- ggplot2::ggplot_build(gg)
 
-  testthat::expect_equal(theme$fontfamily, ggb$plot$theme$text$family)
+  expect_equal(theme$fontfamily, ggb$plot$theme$text$family)
 })
 
-testthat::test_that("T1.8 If `grid` is a single `logical`, it is used for both major and minor grid.", {
+test_that("T1.8 If `grid` is a single `logical`, it is used for both major and minor grid.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -162,14 +162,14 @@ testthat::test_that("T1.8 If `grid` is a single `logical`, it is used for both m
   ggb_grid_true <- ggplot2::ggplot_build(gg_grid_true)
   ggb_grid_false <- ggplot2::ggplot_build(gg_grid_false)
 
-  testthat::expect_true((inherits(ggb_grid_true$plot$theme$panel.grid.major, "element_line")) &
+  expect_true((inherits(ggb_grid_true$plot$theme$panel.grid.major, "element_line")) &
     (inherits(ggb_grid_true$plot$theme$panel.grid.minor, "element_line")))
 
-  testthat::expect_true((inherits(ggb_grid_false$plot$theme$panel.grid.major, "element_blank")) &
+  expect_true((inherits(ggb_grid_false$plot$theme$panel.grid.major, "element_blank")) &
     (inherits(ggb_grid_false$plot$theme$panel.grid.minor, "element_blank")))
 })
 
-testthat::test_that("T1.9 If `grid` is a named list containing 'major' and/or 'minor' as single `logical`s, these are used for their respective options.", {
+test_that("T1.9 If `grid` is a named list containing 'major' and/or 'minor' as single `logical`s, these are used for their respective options.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -195,17 +195,17 @@ testthat::test_that("T1.9 If `grid` is a named list containing 'major' and/or 'm
   ggb_grid_only_minor <- ggplot2::ggplot_build(gg_grid_only_minor)
   ggb_grid_minor_and_major <- ggplot2::ggplot_build(gg_grid_minor_and_major)
 
-  testthat::expect_true((inherits(ggb_grid_none$plot$theme$panel.grid.major, "element_blank")) &
+  expect_true((inherits(ggb_grid_none$plot$theme$panel.grid.major, "element_blank")) &
     (inherits(ggb_grid_none$plot$theme$panel.grid.minor, "element_blank")))
 
-  testthat::expect_true((inherits(ggb_grid_only_minor$plot$theme$panel.grid.major, "element_blank")) &
+  expect_true((inherits(ggb_grid_only_minor$plot$theme$panel.grid.major, "element_blank")) &
     (inherits(ggb_grid_only_minor$plot$theme$panel.grid.minor, "element_line")))
 
-  testthat::expect_true((inherits(ggb_grid_minor_and_major$plot$theme$panel.grid.major, "element_line")) &
+  expect_true((inherits(ggb_grid_minor_and_major$plot$theme$panel.grid.major, "element_line")) &
     (inherits(ggb_grid_minor_and_major$plot$theme$panel.grid.minor, "element_line")))
 })
 
-testthat::test_that("T1.10 A warning when `grid` is a named list containing 'major' and/or 'minor' that are not single `logical`s.", {
+test_that("T1.10 A warning when `grid` is a named list containing 'major' and/or 'minor' that are not single `logical`s.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -219,11 +219,11 @@ testthat::test_that("T1.10 A warning when `grid` is a named list containing 'maj
     "minor" = TRUE
   ))
 
-  testthat::expect_warning(gg %>% visR::apply_theme(theme_major_correct))
-  testthat::expect_warning(gg %>% visR::apply_theme(theme_minor_correct))
+  expect_warning(gg %>% visR::apply_theme(theme_major_correct))
+  expect_warning(gg %>% visR::apply_theme(theme_minor_correct))
 })
 
-testthat::test_that("T1.11 A warning when `grid` is a named list that does not contain 'major' and/or 'minor'.", {
+test_that("T1.11 A warning when `grid` is a named list that does not contain 'major' and/or 'minor'.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -235,10 +235,10 @@ testthat::test_that("T1.11 A warning when `grid` is a named list that does not c
 
   names(theme$grid) <- c("visR", "Rsiv")
 
-  testthat::expect_warning(gg %>% visR::apply_theme(theme))
+  expect_warning(gg %>% visR::apply_theme(theme))
 })
 
-testthat::test_that("T1.12 The background applied through `visR::apply_theme()` is used in the resulting `ggplot` object.", {
+test_that("T1.12 The background applied through `visR::apply_theme()` is used in the resulting `ggplot` object.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -248,10 +248,10 @@ testthat::test_that("T1.12 The background applied through `visR::apply_theme()` 
   gg <- gg %>% visR::apply_theme(theme)
   ggb <- ggplot2::ggplot_build(gg)
 
-  testthat::expect_equal(theme$bg, ggb$plot$theme$panel.background$fill)
+  expect_equal(theme$bg, ggb$plot$theme$panel.background$fill)
 })
 
-testthat::test_that("T1.13 The legend_position applied through `visR::apply_theme()` is used in the resulting `ggplot` object.", {
+test_that("T1.13 The legend_position applied through `visR::apply_theme()` is used in the resulting `ggplot` object.", {
   gg <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()
@@ -271,13 +271,13 @@ testthat::test_that("T1.13 The legend_position applied through `visR::apply_them
   ggb_bottom <- ggplot2::ggplot_build(gg_bottom)
   ggb_left <- ggplot2::ggplot_build(gg_left)
 
-  testthat::expect_equal(theme_top$legend_position, ggb_top$plot$theme$legend.position)
-  testthat::expect_equal(theme_right$legend_position, ggb_right$plot$theme$legend.position)
-  testthat::expect_equal(theme_bottom$legend_position, ggb_bottom$plot$theme$legend.position)
-  testthat::expect_equal(theme_left$legend_position, ggb_left$plot$theme$legend.position)
+  expect_equal(theme_top$legend_position, ggb_top$plot$theme$legend.position)
+  expect_equal(theme_right$legend_position, ggb_right$plot$theme$legend.position)
+  expect_equal(theme_bottom$legend_position, ggb_bottom$plot$theme$legend.position)
+  expect_equal(theme_left$legend_position, ggb_left$plot$theme$legend.position)
 })
 
-testthat::test_that("T1.14 The legend_position defined in `visR::visr()` is used when not defined through `visR::apply_theme()`.", {
+test_that("T1.14 The legend_position defined in `visR::visr()` is used when not defined through `visR::apply_theme()`.", {
   gg_top <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr(legend_position = "top")
@@ -301,13 +301,13 @@ testthat::test_that("T1.14 The legend_position defined in `visR::visr()` is used
   ggb_bottom <- ggplot2::ggplot_build(gg_bottom)
   ggb_left <- ggplot2::ggplot_build(gg_left)
 
-  testthat::expect_true("top" %in% ggb_top$plot$theme$legend.position)
-  testthat::expect_true("right" %in% ggb_right$plot$theme$legend.position)
-  testthat::expect_true("bottom" %in% ggb_bottom$plot$theme$legend.position)
-  testthat::expect_true("left" %in% ggb_left$plot$theme$legend.position)
+  expect_true("top" %in% ggb_top$plot$theme$legend.position)
+  expect_true("right" %in% ggb_right$plot$theme$legend.position)
+  expect_true("bottom" %in% ggb_bottom$plot$theme$legend.position)
+  expect_true("left" %in% ggb_left$plot$theme$legend.position)
 })
 
-testthat::test_that("T1.15 If a stratum has no colour assigned, the default colour (grey50) is used.", {
+test_that("T1.15 If a stratum has no colour assigned, the default colour (grey50) is used.", {
   theme <- visR::define_theme(
     strata = list(
       "SEX" = list(
@@ -339,8 +339,8 @@ testthat::test_that("T1.15 If a stratum has no colour assigned, the default colo
 
   ggb <- ggplot2::ggplot_build(gg)
 
-  testthat::expect_true("grey50" %in% unlist(unique(ggb$data[[1]]["fill"])))
-  testthat::expect_true("blue" %in% unlist(unique(ggb$data[[1]]["fill"])))
+  expect_true("grey50" %in% unlist(unique(ggb$data[[1]]["fill"])))
+  expect_true("blue" %in% unlist(unique(ggb$data[[1]]["fill"])))
 
   ## example 2
   theme <- visR::define_theme(
@@ -363,12 +363,12 @@ testthat::test_that("T1.15 If a stratum has no colour assigned, the default colo
   ggb <- ggplot2::ggplot_build(gg)
 
   cols <- unlist(unique(ggb$data[[1]]["fill"]))
-  testthat::expect_true("grey50" %in% cols)
-  testthat::expect_true("red" %in% cols)
-  testthat::expect_true("blue" %in% cols)
+  expect_true("grey50" %in% cols)
+  expect_true("red" %in% cols)
+  expect_true("blue" %in% cols)
 })
 
-testthat::test_that("T1.16 If no strata colors can be mapped to the graph, the default visR palette is used as long as there are less than 15 strata levels.", {
+test_that("T1.16 If no strata colors can be mapped to the graph, the default visR palette is used as long as there are less than 15 strata levels.", {
 
   ## example 1
   theme <- visR::define_theme(
@@ -401,7 +401,7 @@ testthat::test_that("T1.16 If no strata colors can be mapped to the graph, the d
   cols <- unlist(unique(ggb$data[[1]]["fill"]))
   names(cols) <- NULL
 
-  testthat::expect_true(length(setdiff(c("#000000", "#490092", "#920000", "#009292", "#B66DFF", "#DBD100", "#FFB677"), cols)) == 0)
+  expect_true(length(setdiff(c("#000000", "#490092", "#920000", "#009292", "#B66DFF", "#DBD100", "#FFB677"), cols)) == 0)
 
   ## example 2
   theme <- visR::define_theme()
@@ -421,10 +421,10 @@ testthat::test_that("T1.16 If no strata colors can be mapped to the graph, the d
   cols <- unlist(unique(ggb$data[[1]]["fill"]))
   names(cols) <- NULL
 
-  testthat::expect_true(length(setdiff(c("#000000"), cols)) == 0)
+  expect_true(length(setdiff(c("#000000"), cols)) == 0)
 })
 
-testthat::test_that("T1.17 If no strata colors can be mapped to the graph, the original colors are retained if there are more than 15 strata levels.", {
+test_that("T1.17 If no strata colors can be mapped to the graph, the original colors are retained if there are more than 15 strata levels.", {
 
   ## not a relevant strata list, but is required to test the requirement easily
   theme <- visR::define_theme(
@@ -465,10 +465,10 @@ testthat::test_that("T1.17 If no strata colors can be mapped to the graph, the o
   cols <- unlist(unique(ggb$data[[1]]["fill"]))
   names(cols) <- NULL
 
-  testthat::expect_true(length(cols_expected %in% cols) > 1)
+  expect_true(length(cols_expected %in% cols) > 1)
 })
 
-testthat::test_that("T1.18 If no strata colors can be mapped to the graph, a warning about the presence of more than 15 strata levels.", {
+test_that("T1.18 If no strata colors can be mapped to the graph, a warning about the presence of more than 15 strata levels.", {
 
   ## not a relevant strata list, but is required to test the requirement easily
   theme <- visR::define_theme(
@@ -502,10 +502,10 @@ testthat::test_that("T1.18 If no strata colors can be mapped to the graph, a war
     dplyr::rename(Age = "age", Sex = "sex", Status = "status", Days = "time") %>%
     visR::estimate_KM(strata = c("Age", "pat.karno"), CNSR = "Status", AVAL = "Days")
 
-  testthat::expect_warning(survobj %>% visR::visr() %>% apply_theme(theme))
+  expect_warning(survobj %>% visR::visr() %>% apply_theme(theme))
 })
 
-testthat::test_that("T1.19 The named list is used in the legend title.", {
+test_that("T1.19 The named list is used in the legend title.", {
   theme <- visR::define_theme(
     strata = list(
       "SEX" = list(
@@ -536,7 +536,7 @@ testthat::test_that("T1.19 The named list is used in the legend title.", {
     visR::apply_theme(theme)
 
 
-  testthat::expect_equal(get_legend_title(gg), "SEX")
+  expect_equal(get_legend_title(gg), "SEX")
 
   ## example 2
   theme <- visR::define_theme(
@@ -556,10 +556,10 @@ testthat::test_that("T1.19 The named list is used in the legend title.", {
     visR::visr() %>%
     visR::apply_theme(theme)
 
-  testthat::expect_equal(get_legend_title(gg), "Sex, ph.ecog")
+  expect_equal(get_legend_title(gg), "Sex, ph.ecog")
 })
 
-# testthat::test_that("T1.18 When the strata requires more colours than the visR palette holds, the default ggplot2 ones are chosen.", {
+# test_that("T1.18 When the strata requires more colours than the visR palette holds, the default ggplot2 ones are chosen.", {
 #
 #   theme <- visR::define_theme(strata = list("TRTDUR" = list("F" = "red",
 #                                                          "M" = "blue")),
@@ -587,7 +587,7 @@ testthat::test_that("T1.19 The named list is used in the legend title.", {
 #   cols_observed <- gsub(".{2}$", "", cols_observed)
 #   names(cols_observed) <- NULL
 #
-#   testthat::expect_equal(cols_expected, cols_observed)
+#   expect_equal(cols_expected, cols_observed)
 #
 # })
 

--- a/tests/testthat/test-define_theme.R
+++ b/tests/testthat/test-define_theme.R
@@ -40,157 +40,157 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("define_theme - T1. `define_theme()` returns a `visR_theme` object.")
+context("define_theme - T1. `define_theme()` returns a `visR_theme` object.")
 
-testthat::test_that("T1.1 `define_theme()` returns a list of class `visR_theme`.", {
-  testthat::expect_true(inherits(visR::define_theme(), "visR_theme"))
-  testthat::expect_true(inherits(visR::define_theme(), "list"))
+test_that("T1.1 `define_theme()` returns a list of class `visR_theme`.", {
+  expect_true(inherits(visR::define_theme(), "visR_theme"))
+  expect_true(inherits(visR::define_theme(), "list"))
 })
 
-testthat::test_that("T1.2 No error when no parameters are specified.", {
-  testthat::expect_error(visR::define_theme(), NA)
+test_that("T1.2 No error when no parameters are specified.", {
+  expect_error(visR::define_theme(), NA)
 })
 
 # Requirement T2 ----------------------------------------------------------
 
-testthat::context("define_theme - T2. The function accepts `strata` as argument.")
+context("define_theme - T2. The function accepts `strata` as argument.")
 
-testthat::test_that("T2.1 No error when `strata` is `NULL`.", {
-  testthat::expect_error(visR::define_theme(strata = NULL), NA)
+test_that("T2.1 No error when `strata` is `NULL`.", {
+  expect_error(visR::define_theme(strata = NULL), NA)
 })
 
-testthat::test_that("T2.2 A warning when `strata` is an empty `list`.", {
-  testthat::expect_warning(visR::define_theme(strata = list()))
+test_that("T2.2 A warning when `strata` is an empty `list`.", {
+  expect_warning(visR::define_theme(strata = list()))
 })
 
-testthat::test_that("T2.3 A warning when `strata` is an unnamed `list`.", {
-  testthat::expect_warning(visR::define_theme(strata = list("v", "i", "s", "R")))
+test_that("T2.3 A warning when `strata` is an unnamed `list`.", {
+  expect_warning(visR::define_theme(strata = list("v", "i", "s", "R")))
 })
 
-testthat::test_that("T2.4 No warning when `strata` is a named `list`.", {
-  testthat::expect_warning(visR::define_theme(strata = list("visR" = "visR")), NA)
+test_that("T2.4 No warning when `strata` is a named `list`.", {
+  expect_warning(visR::define_theme(strata = list("visR" = "visR")), NA)
 })
 
 # Requirement T3 ----------------------------------------------------------
 
-testthat::context("define_theme - T3. The function accepts `fontsizes` as argument.")
+context("define_theme - T3. The function accepts `fontsizes` as argument.")
 
-testthat::test_that("T3.1 No error when `fontsizes` is undefined.", {
-  testthat::expect_error(visR::define_theme(), NA)
+test_that("T3.1 No error when `fontsizes` is undefined.", {
+  expect_error(visR::define_theme(), NA)
 })
 
-testthat::test_that("T3.2 A warning when `fontsizes` is an empty `list`.", {
-  testthat::expect_warning(visR::define_theme(fontsizes = list()))
+test_that("T3.2 A warning when `fontsizes` is an empty `list`.", {
+  expect_warning(visR::define_theme(fontsizes = list()))
 })
 
-testthat::test_that("T3.3 A warning when `fontsizes` is `character`.", {
-  testthat::expect_warning(visR::define_theme(fontsizes = "NULL"))
+test_that("T3.3 A warning when `fontsizes` is `character`.", {
+  expect_warning(visR::define_theme(fontsizes = "NULL"))
 })
 
-testthat::test_that("T3.4 A message when `fontsizes` is a numerical value.", {
-  testthat::expect_message(visR::define_theme(fontsizes = 12))
+test_that("T3.4 A message when `fontsizes` is a numerical value.", {
+  expect_message(visR::define_theme(fontsizes = 12))
 })
 
-testthat::test_that("T3.5 A warning when `fontsizes` is an unnamed `list`.", {
-  testthat::expect_warning(visR::define_theme(fontsizes = list("s", "R")))
+test_that("T3.5 A warning when `fontsizes` is an unnamed `list`.", {
+  expect_warning(visR::define_theme(fontsizes = list("s", "R")))
 })
 
-testthat::test_that("T3.6 No warning when `fontsizes` is a named `list`.", {
-  testthat::expect_warning(visR::define_theme(fontsizes = list("a" = "a")), NA)
+test_that("T3.6 No warning when `fontsizes` is a named `list`.", {
+  expect_warning(visR::define_theme(fontsizes = list("a" = "a")), NA)
 })
 
 # Requirement T4 ----------------------------------------------------------
 
-testthat::context("define_theme - T4. The function accepts `fontfamily` as argument.")
+context("define_theme - T4. The function accepts `fontfamily` as argument.")
 
-testthat::test_that("T4.1 No error when `fontfamily` is a string.", {
-  testthat::expect_error(visR::define_theme(fontfamily = "Times"), NA)
+test_that("T4.1 No error when `fontfamily` is a string.", {
+  expect_error(visR::define_theme(fontfamily = "Times"), NA)
 })
 
-testthat::test_that("T4.2 A warning when `fontfamily` is an empty string.", {
-  testthat::expect_warning(visR::define_theme(fontfamily = ""))
-  testthat::expect_warning(visR::define_theme(fontfamily = c("")))
+test_that("T4.2 A warning when `fontfamily` is an empty string.", {
+  expect_warning(visR::define_theme(fontfamily = ""))
+  expect_warning(visR::define_theme(fontfamily = c("")))
 })
 
-testthat::test_that("T4.3 A warning when `fontfamily` is a vector of strings.", {
-  testthat::expect_warning(visR::define_theme(fontfamily = c("a", "a")))
+test_that("T4.3 A warning when `fontfamily` is a vector of strings.", {
+  expect_warning(visR::define_theme(fontfamily = c("a", "a")))
 })
 
-testthat::test_that("T4.4 A warning when `fontfamily` is anything but a string.", {
-  testthat::expect_warning(visR::define_theme(fontfamily = NULL))
-  testthat::expect_warning(visR::define_theme(fontfamily = 12))
-  testthat::expect_warning(visR::define_theme(fontfamily = TRUE))
-  testthat::expect_warning(visR::define_theme(fontfamily = list()))
+test_that("T4.4 A warning when `fontfamily` is anything but a string.", {
+  expect_warning(visR::define_theme(fontfamily = NULL))
+  expect_warning(visR::define_theme(fontfamily = 12))
+  expect_warning(visR::define_theme(fontfamily = TRUE))
+  expect_warning(visR::define_theme(fontfamily = list()))
 })
 
 # Requirement T5 ----------------------------------------------------------
 
-testthat::context("define_theme - T5. The function accepts `grid` as argument.")
+context("define_theme - T5. The function accepts `grid` as argument.")
 
-testthat::test_that("T5.1 No error when `grid` is a boolean.", {
-  testthat::expect_error(visR::define_theme(grid = TRUE), NA)
-  testthat::expect_error(visR::define_theme(grid = FALSE), NA)
+test_that("T5.1 No error when `grid` is a boolean.", {
+  expect_error(visR::define_theme(grid = TRUE), NA)
+  expect_error(visR::define_theme(grid = FALSE), NA)
 })
 
-testthat::test_that("T5.2 No error when `grid` is a named list with elements `major` `minor`.", {
-  testthat::expect_error(visR::define_theme(grid = list("major" = TRUE, "minor" = FALSE)), NA)
-  testthat::expect_error(visR::define_theme(grid = list("major" = TRUE)), NA)
-  testthat::expect_error(visR::define_theme(grid = list("minor" = TRUE)), NA)
+test_that("T5.2 No error when `grid` is a named list with elements `major` `minor`.", {
+  expect_error(visR::define_theme(grid = list("major" = TRUE, "minor" = FALSE)), NA)
+  expect_error(visR::define_theme(grid = list("major" = TRUE)), NA)
+  expect_error(visR::define_theme(grid = list("minor" = TRUE)), NA)
 })
 
-testthat::test_that("T5.3 A warning when `grid` is a unnmaed list.", {
-  testthat::expect_warning(visR::define_theme(grid = list(TRUE, TRUE)))
+test_that("T5.3 A warning when `grid` is a unnmaed list.", {
+  expect_warning(visR::define_theme(grid = list(TRUE, TRUE)))
 })
 
-testthat::test_that("T5.4 A warning when `grid` is a named list without elements `major` `minor`.", {
-  testthat::expect_warning(visR::define_theme(grid = list("visR" = TRUE)))
+test_that("T5.4 A warning when `grid` is a named list without elements `major` `minor`.", {
+  expect_warning(visR::define_theme(grid = list("visR" = TRUE)))
 })
 
-testthat::test_that("T5.5 A warning when `grid` is anything but a boolean or a list.", {
-  testthat::expect_warning(visR::define_theme(grid = NULL))
-  testthat::expect_warning(visR::define_theme(grid = 12))
-  testthat::expect_warning(visR::define_theme(grid = "visR"))
-  testthat::expect_warning(visR::define_theme(grid = c()))
+test_that("T5.5 A warning when `grid` is anything but a boolean or a list.", {
+  expect_warning(visR::define_theme(grid = NULL))
+  expect_warning(visR::define_theme(grid = 12))
+  expect_warning(visR::define_theme(grid = "visR"))
+  expect_warning(visR::define_theme(grid = c()))
 })
 
 # Requirement T6 ----------------------------------------------------------
 
-testthat::context("define_theme - T6. The function accepts `bg` as argument.")
+context("define_theme - T6. The function accepts `bg` as argument.")
 
-testthat::test_that("T6.1 No error when `bg` is a character.", {
-  testthat::expect_error(visR::define_theme(bg = "blue"), NA)
+test_that("T6.1 No error when `bg` is a character.", {
+  expect_error(visR::define_theme(bg = "blue"), NA)
 })
 
-testthat::test_that("T6.2 A warning when `bg` is anything but a character.", {
-  testthat::expect_warning(visR::define_theme(bg = NULL))
-  testthat::expect_warning(visR::define_theme(bg = 12))
-  testthat::expect_warning(visR::define_theme(bg = list()))
+test_that("T6.2 A warning when `bg` is anything but a character.", {
+  expect_warning(visR::define_theme(bg = NULL))
+  expect_warning(visR::define_theme(bg = 12))
+  expect_warning(visR::define_theme(bg = list()))
 })
 
 # Requirement T7 ----------------------------------------------------------
 
-testthat::context("define_theme - T7. The function accepts `legend_position` as argument.")
+context("define_theme - T7. The function accepts `legend_position` as argument.")
 
-testthat::test_that("T7.1 `legend_position` accept 4 different strings `top` `right` `bottom` `left`.", {
-  testthat::expect_error(visR::define_theme(legend_position = "top"), NA)
-  testthat::expect_error(visR::define_theme(legend_position = "bottom"), NA)
-  testthat::expect_error(visR::define_theme(legend_position = "left"), NA)
-  testthat::expect_error(visR::define_theme(legend_position = "right"), NA)
-  testthat::expect_warning(visR::define_theme(legend_position = "top"), NA)
-  testthat::expect_warning(visR::define_theme(legend_position = "bottom"), NA)
-  testthat::expect_warning(visR::define_theme(legend_position = "left"), NA)
-  testthat::expect_warning(visR::define_theme(legend_position = "right"), NA)
+test_that("T7.1 `legend_position` accept 4 different strings `top` `right` `bottom` `left`.", {
+  expect_error(visR::define_theme(legend_position = "top"), NA)
+  expect_error(visR::define_theme(legend_position = "bottom"), NA)
+  expect_error(visR::define_theme(legend_position = "left"), NA)
+  expect_error(visR::define_theme(legend_position = "right"), NA)
+  expect_warning(visR::define_theme(legend_position = "top"), NA)
+  expect_warning(visR::define_theme(legend_position = "bottom"), NA)
+  expect_warning(visR::define_theme(legend_position = "left"), NA)
+  expect_warning(visR::define_theme(legend_position = "right"), NA)
 })
 
-testthat::test_that("T7.2 `legend_position` accepts NULL.", {
-  testthat::expect_error(visR::define_theme(legend_position = NULL), NA)
-  testthat::expect_warning(visR::define_theme(legend_position = NULL), NA)
+test_that("T7.2 `legend_position` accepts NULL.", {
+  expect_error(visR::define_theme(legend_position = NULL), NA)
+  expect_warning(visR::define_theme(legend_position = NULL), NA)
 })
 
-testthat::test_that("T7.3 A warning when `legend_position` is not NULL nor a string equal to `top` `right` `bottom` `left`.", {
-  testthat::expect_warning(visR::define_theme(legend_position = "visR"))
-  testthat::expect_warning(visR::define_theme(legend_position = 12))
-  testthat::expect_warning(visR::define_theme(legend_position = list()))
+test_that("T7.3 A warning when `legend_position` is not NULL nor a string equal to `top` `right` `bottom` `left`.", {
+  expect_warning(visR::define_theme(legend_position = "visR"))
+  expect_warning(visR::define_theme(legend_position = 12))
+  expect_warning(visR::define_theme(legend_position = list()))
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-estimate_KM.R
+++ b/tests/testthat/test-estimate_KM.R
@@ -50,146 +50,146 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("estimate_KM - T1. The function accepts a `data.frame` `tibble` or `data.table`")
+context("estimate_KM - T1. The function accepts a `data.frame` `tibble` or `data.table`")
 
-testthat::test_that("T1.1 No error when `data` is of class `data.frame`", {
+test_that("T1.1 No error when `data` is of class `data.frame`", {
   data <- adtte
-  testthat::expect_error(visR::estimate_KM(data = data), NA)
+  expect_error(visR::estimate_KM(data = data), NA)
 })
 
 
-testthat::test_that("T1.2 No error when `data` is of class `tibble`", {
+test_that("T1.2 No error when `data` is of class `tibble`", {
   data <- dplyr::as_tibble(adtte)
-  testthat::expect_error(visR::estimate_KM(data = data), NA)
+  expect_error(visR::estimate_KM(data = data), NA)
 })
 
-testthat::test_that("T1.3 No error when `data` is of class `data.table`", {
+test_that("T1.3 No error when `data` is of class `data.table`", {
   if (nzchar(find.package("data.table"))) {
     data <- data.table::as.data.table(adtte)
-    testthat::expect_error(visR::estimate_KM(data = data), NA)
+    expect_error(visR::estimate_KM(data = data), NA)
   }
 })
 
-testthat::test_that("T1.4 An error when `data` is of an unexpected class, eg `list`", {
+test_that("T1.4 An error when `data` is of an unexpected class, eg `list`", {
   data <- base::as.list(adtte)
-  testthat::expect_error(visR::estimate_KM(data = data))
+  expect_error(visR::estimate_KM(data = data))
 })
 
-testthat::test_that("T1.5 An error when `data` is NULL", {
-  testthat::expect_error(visR::estimate_KM(data = NULL))
+test_that("T1.5 An error when `data` is NULL", {
+  expect_error(visR::estimate_KM(data = NULL))
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("estimate_KM - T2. The function relies on the presence of two numeric variables, specified through `AVAL` and `CNSR`, to be present in `data` when relying on the CDISC ADaM model")
+context("estimate_KM - T2. The function relies on the presence of two numeric variables, specified through `AVAL` and `CNSR`, to be present in `data` when relying on the CDISC ADaM model")
 
-testthat::test_that("T2.1 An error when column name specified through `AVAL` is not present in `data`", {
+test_that("T2.1 An error when column name specified through `AVAL` is not present in `data`", {
   data <- adtte[, -which(colnames(adtte) == "AVAL")]
 
-  testthat::expect_error(visR::estimate_KM(data = data))
+  expect_error(visR::estimate_KM(data = data))
 })
 
-testthat::test_that("T2.2 An error when column name specified through `AVAL` is not numeric", {
+test_that("T2.2 An error when column name specified through `AVAL` is not numeric", {
   data <- adtte
   data[["AVAL"]] <- as.character(data[["AVAL"]])
 
-  testthat::expect_error(visR::estimate_KM(data = data))
+  expect_error(visR::estimate_KM(data = data))
 })
 
-testthat::test_that("T2.3 No error when the column name specified through `AVAL` is not the proposed default", {
+test_that("T2.3 No error when the column name specified through `AVAL` is not the proposed default", {
   data <- adtte
   data$AVAL2 <- data$AVAL
   data <- data[, -which(colnames(adtte) == "AVAL")]
 
-  testthat::expect_error(visR::estimate_KM(data = data, AVAL = "AVAL2"), NA)
+  expect_error(visR::estimate_KM(data = data, AVAL = "AVAL2"), NA)
 })
 
-testthat::test_that("T2.4 An error when the column name specified through `CNSR` is not present in `data`", {
+test_that("T2.4 An error when the column name specified through `CNSR` is not present in `data`", {
   data <- adtte[, -which(colnames(adtte) == "CNSR")]
 
-  testthat::expect_error(visR::estimate_KM(data = data))
+  expect_error(visR::estimate_KM(data = data))
 })
 
-testthat::test_that("T2.5 An error when the column name specified through `CNSR` is not numeric", {
+test_that("T2.5 An error when the column name specified through `CNSR` is not numeric", {
   data <- adtte
   data[["CNSR"]] <- as.character(data[["CNSR"]])
 
-  testthat::expect_error(visR::estimate_KM(data = data))
+  expect_error(visR::estimate_KM(data = data))
 })
 
-testthat::test_that("T2.6 No error when the column name specified through `CNSR` is not the proposed default", {
+test_that("T2.6 No error when the column name specified through `CNSR` is not the proposed default", {
   data <- adtte
   data$CNSR2 <- data$CNSR
   data <- dplyr::select(data, -CNSR)
 
-  testthat::expect_error(visR::estimate_KM(data = data, CNSR = "CNSR2"), NA)
+  expect_error(visR::estimate_KM(data = data, CNSR = "CNSR2"), NA)
 })
 
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("estimate_KM - T3. The user can specify strata when relying on the CDISC ADaM model")
+context("estimate_KM - T3. The user can specify strata when relying on the CDISC ADaM model")
 
-testthat::test_that("T3.1 An error when the columns, specifying the strata are not available in `data`", {
+test_that("T3.1 An error when the columns, specifying the strata are not available in `data`", {
   data <- adtte
-  testthat::expect_error(visR::estimate_KM(data = data, strata = "blah"))
+  expect_error(visR::estimate_KM(data = data, strata = "blah"))
 })
 
-testthat::test_that("T3.2 No error when strata is NULL", {
+test_that("T3.2 No error when strata is NULL", {
   data <- adtte
-  testthat::expect_error(visR::estimate_KM(data = data, strata = NULL), NA)
+  expect_error(visR::estimate_KM(data = data, strata = NULL), NA)
 })
 
-testthat::test_that("T3.3 When no strata are specified, an artificial strata is created 'Overall'", {
+test_that("T3.3 When no strata are specified, an artificial strata is created 'Overall'", {
   data <- adtte
   survobj <- visR::estimate_KM(data = data, strata = NULL)
 
-  testthat::expect_equal(names(survobj[["strata"]]), "Overall")
+  expect_equal(names(survobj[["strata"]]), "Overall")
 })
 
-testthat::test_that("T3.4 When 1 stratum is specified, the stratum levels are added to the `names` attribute'", {
+test_that("T3.4 When 1 stratum is specified, the stratum levels are added to the `names` attribute'", {
   data <- adtte
   survobj <- visR::estimate_KM(data = data, strata = "SEX")
 
-  testthat::expect_equal(names(survobj[["strata"]]), c("SEX=F", "SEX=M"))
+  expect_equal(names(survobj[["strata"]]), c("SEX=F", "SEX=M"))
 })
 
-testthat::test_that("T3.5 When more than 1 strata is specified, the stratum names are available in the `names` attribute", {
+test_that("T3.5 When more than 1 strata is specified, the stratum names are available in the `names` attribute", {
   data <- adtte
   survobj <- visR::estimate_KM(data = data, strata = c("TRTP", "SEX"))
 
-  testthat::expect_equal(names(survobj[["strata"]]), c(
+  expect_equal(names(survobj[["strata"]]), c(
     "TRTP=Placebo, SEX=F", "TRTP=Placebo, SEX=M", "TRTP=Xanomeline High Dose, SEX=F",
     "TRTP=Xanomeline High Dose, SEX=M", "TRTP=Xanomeline Low Dose, SEX=F",
     "TRTP=Xanomeline Low Dose, SEX=M"
   ))
 })
 
-testthat::test_that("T3.6 When no strata are specified, the stratum label is NULL", {
+test_that("T3.6 When no strata are specified, the stratum label is NULL", {
   data <- adtte
   survobj <- visR::estimate_KM(data = data, strata = NULL)
 
-  testthat::expect_true(is.null(survobj$strata_lbls))
+  expect_true(is.null(survobj$strata_lbls))
 })
 
-testthat::test_that("T3.7 When 1 strata is specified, the stratum labels are available in the `strata_lbs` list element", {
+test_that("T3.7 When 1 strata is specified, the stratum labels are available in the `strata_lbs` list element", {
   data <- adtte
   survobj <- visR::estimate_KM(data = data, strata = "SEX")
 
-  testthat::expect_equal(survobj$strata_lbls, list(SEX = "Sex"))
+  expect_equal(survobj$strata_lbls, list(SEX = "Sex"))
 })
 
-testthat::test_that("T3.8 When more than 1 strata is specified, the stratum labels are available in the `strata_lbs` list element", {
+test_that("T3.8 When more than 1 strata is specified, the stratum labels are available in the `strata_lbs` list element", {
   survobj <- visR::estimate_KM(data = adtte, strata = c("RACE", "SEX"))
 
-  testthat::expect_equal(survobj$strata_lbls, list(RACE = "Race", SEX = "Sex"))
+  expect_equal(survobj$strata_lbls, list(RACE = "Race", SEX = "Sex"))
 })
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("estimate_KM - T4. The function removes all rows with NA values inside any of the variables required for the analysis")
+context("estimate_KM - T4. The function removes all rows with NA values inside any of the variables required for the analysis")
 
-testthat::test_that("T4.1 The function removes all rows with NA values inside any of the strata, CNSR or AVAL", {
+test_that("T4.1 The function removes all rows with NA values inside any of the strata, CNSR or AVAL", {
   data <- adtte
   data[1:10, "SEX"] <- NA
   data[11:20, "AVAL"] <- NA
@@ -202,10 +202,10 @@ testthat::test_that("T4.1 The function removes all rows with NA values inside an
   data <- tidyr::drop_na(data, AVAL, CNSR, SEX)
   survobjNA <- visR::estimate_KM(data = data, strata = "SEX")
 
-  testthat::expect_equal(survobjNA, survobj)
+  expect_equal(survobjNA, survobj)
 })
 
-testthat::test_that("T4.2 The function removes all rows with NA values inside any of the variables of the `formula` argument", {
+test_that("T4.2 The function removes all rows with NA values inside any of the variables of the `formula` argument", {
   data <- adtte
   data[1:10, "SEX"] <- NA
   data[11:20, "AVAL"] <- NA
@@ -218,47 +218,14 @@ testthat::test_that("T4.2 The function removes all rows with NA values inside an
   data <- tidyr::drop_na(data, AVAL, CNSR, SEX)
   survobjNA <- visR::estimate_KM(data = data, strata = "SEX")
 
-  testthat::expect_equal(survobjNA, survobj)
+  expect_equal(survobjNA, survobj)
 })
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("estimate_KM - T5. The function does not alter the calculation of survival::survfit")
+context("estimate_KM - T5. The function does not alter the calculation of survival::survfit")
 
-testthat::test_that("T5.1 The function gives the same results as survival::survfit", {
-
-  ## survival package
-  survobj_survival <- survival::survfit(survival::Surv(AVAL, 1 - CNSR) ~ SEX,
-    data = adtte
-  )
-  survobj_survival <- survival::survfit0(survobj_survival, start.time = 0)
-
-  ## visR
-  survobj_visR <- visR::estimate_KM(data = adtte, strata = "SEX")
-
-  # Compare common elements
-  Common_Nms <- base::intersect(names(survobj_survival), names(survobj_visR))
-  Common_Nms <- Common_Nms[-which(Common_Nms == "call")]
-
-  list_survival <- lapply(survobj_survival, "[")[Common_Nms]
-  list_visR <- lapply(survobj_visR, "[")[Common_Nms]
-
-  testthat::expect_equal(list_survival, list_visR)
-
-  ## visR - formula
-  survobj_visR <- visR::estimate_KM(data = adtte, formula = survival::Surv(AVAL, 1 - CNSR) ~ SEX)
-
-  # Compare common elements
-  Common_Nms <- base::intersect(names(survobj_survival), names(survobj_visR))
-  Common_Nms <- Common_Nms[-which(Common_Nms == "call")]
-
-  list_survival <- lapply(survobj_survival, "[")[Common_Nms]
-  list_visR <- lapply(survobj_visR, "[")[Common_Nms]
-
-  testthat::expect_equal(list_survival, list_visR)
-})
-
-testthat::test_that("T5.2 The function adds timepoint = 0", {
+test_that("T5.1 The function gives the same results as survival::survfit", {
 
   ## survival package
   survobj_survival <- survival::survfit(survival::Surv(AVAL, 1 - CNSR) ~ SEX,
@@ -273,11 +240,44 @@ testthat::test_that("T5.2 The function adds timepoint = 0", {
   Common_Nms <- base::intersect(names(survobj_survival), names(survobj_visR))
   Common_Nms <- Common_Nms[-which(Common_Nms == "call")]
 
+  list_survival <- lapply(survobj_survival, "[")[Common_Nms]
+  list_visR <- lapply(survobj_visR, "[")[Common_Nms]
+
+  expect_equal(list_survival, list_visR)
+
+  ## visR - formula
+  survobj_visR <- visR::estimate_KM(data = adtte, formula = survival::Surv(AVAL, 1 - CNSR) ~ SEX)
+
+  # Compare common elements
+  Common_Nms <- base::intersect(names(survobj_survival), names(survobj_visR))
+  Common_Nms <- Common_Nms[-which(Common_Nms == "call")]
 
   list_survival <- lapply(survobj_survival, "[")[Common_Nms]
   list_visR <- lapply(survobj_visR, "[")[Common_Nms]
 
-  testthat::expect_equal(list_survival, list_visR)
+  expect_equal(list_survival, list_visR)
+})
+
+test_that("T5.2 The function adds timepoint = 0", {
+
+  ## survival package
+  survobj_survival <- survival::survfit(survival::Surv(AVAL, 1 - CNSR) ~ SEX,
+    data = adtte
+  )
+  survobj_survival <- survival::survfit0(survobj_survival, start.time = 0)
+
+  ## visR
+  survobj_visR <- visR::estimate_KM(data = adtte, strata = "SEX")
+
+  # Compare common elements
+  Common_Nms <- base::intersect(names(survobj_survival), names(survobj_visR))
+  Common_Nms <- Common_Nms[-which(Common_Nms == "call")]
+
+
+  list_survival <- lapply(survobj_survival, "[")[Common_Nms]
+  list_visR <- lapply(survobj_visR, "[")[Common_Nms]
+
+  expect_equal(list_survival, list_visR)
 
   ## visR - formula
   survobj_visR <- visR::estimate_KM(data = adtte, formula = survival::Surv(AVAL, 1 - CNSR) ~ SEX)
@@ -290,10 +290,10 @@ testthat::test_that("T5.2 The function adds timepoint = 0", {
   list_survival <- lapply(survobj_survival, "[")[Common_Nms]
   list_visR <- lapply(survobj_visR, "[")[Common_Nms]
 
-  testthat::expect_equal(list_survival, list_visR)
+  expect_equal(list_survival, list_visR)
 })
 
-testthat::test_that("T5.3 The function allows additional arguments to be passed, specific for survival::survfit", {
+test_that("T5.3 The function allows additional arguments to be passed, specific for survival::survfit", {
 
   ## survival package
   survobj_survival <- survival::survfit(survival::Surv(AVAL, 1 - CNSR) ~ SEX,
@@ -318,7 +318,7 @@ testthat::test_that("T5.3 The function allows additional arguments to be passed,
   list_survival <- lapply(survobj_survival, "[")[Common_Nms]
   list_visR <- lapply(survobj_visR, "[")[Common_Nms]
 
-  testthat::expect_equal(list_survival, list_visR)
+  expect_equal(list_survival, list_visR)
 
   ## visR - formula
   survobj_visR <- visR::estimate_KM(
@@ -334,10 +334,10 @@ testthat::test_that("T5.3 The function allows additional arguments to be passed,
   list_survival <- lapply(survobj_survival, "[")[Common_Nms]
   list_visR <- lapply(survobj_visR, "[")[Common_Nms]
 
-  testthat::expect_equal(list_survival, list_visR)
+  expect_equal(list_survival, list_visR)
 })
 
-testthat::test_that("T5.4 The function returns an object of class `survfit`", {
+test_that("T5.4 The function returns an object of class `survfit`", {
 
   ## visR
   survobj_visR <- visR::estimate_KM(
@@ -347,7 +347,7 @@ testthat::test_that("T5.4 The function returns an object of class `survfit`", {
     conf.type = "plain"
   )
 
-  testthat::expect_true(inherits(survobj_visR, "survfit"))
+  expect_true(inherits(survobj_visR, "survfit"))
 
   ## visR - formula
   survobj_visR <- visR::estimate_KM(
@@ -356,90 +356,90 @@ testthat::test_that("T5.4 The function returns an object of class `survfit`", {
     conf.type = "plain"
   )
 
-  testthat::expect_true(inherits(survobj_visR, "survfit"))
+  expect_true(inherits(survobj_visR, "survfit"))
 })
 
 # Requirement T6 ---------------------------------------------------------------
 
-testthat::context("estimate_KM - T6. The function adds additional information to the survfit object when available")
+context("estimate_KM - T6. The function adds additional information to the survfit object when available")
 
-testthat::test_that("T6.1 The function adds PARAM/PARAMCD when available", {
+test_that("T6.1 The function adds PARAM/PARAMCD when available", {
   survobj <- visR::estimate_KM(data = adtte, strata = "SEX")
 
-  testthat::expect_equal(survobj[["PARAMCD"]], "TTDE")
-  testthat::expect_equal(survobj[["PARAM"]], "Time to First Dermatologic Event")
+  expect_equal(survobj[["PARAMCD"]], "TTDE")
+  expect_equal(survobj[["PARAM"]], "Time to First Dermatologic Event")
 })
 
-testthat::test_that("T6.2 The function adds strata labels from the data when available", {
+test_that("T6.2 The function adds strata labels from the data when available", {
   survobj <- visR::estimate_KM(data = adtte, strata = "SEX")
 
-  testthat::expect_equal(survobj$strata_lbls, list(SEX = "Sex"))
+  expect_equal(survobj$strata_lbls, list(SEX = "Sex"))
 })
 
-testthat::test_that("T6.3 The function adds strata labels equal to the strata name when strata labels are not available from the data", {
+test_that("T6.3 The function adds strata labels equal to the strata name when strata labels are not available from the data", {
   data <- adtte
   attr(data[["SEX"]], "label") <- NULL
   survobj <- visR::estimate_KM(data = data, strata = "SEX")
 
-  testthat::expect_equal(survobj$strata_lbls, list(SEX = "SEX"))
+  expect_equal(survobj$strata_lbls, list(SEX = "SEX"))
 })
 
-testthat::test_that("T6.4 The function adds the data set name", {
+test_that("T6.4 The function adds the data set name", {
   survobj <- visR::estimate_KM(data = adtte, strata = "SEX")
-  testthat::expect_equal(survobj$data_name, "adtte")
+  expect_equal(survobj$data_name, "adtte")
 
   survobj <- visR::estimate_KM(data = adtte[adtte$SEX == "F", ], strata = "RACE")
-  testthat::expect_equal(survobj$data_name, "adtte")
+  expect_equal(survobj$data_name, "adtte")
 
   survobj <- adtte %>%
     dplyr::filter(SEX == "F") %>%
     visR::estimate_KM(data = ., strata = "RACE")
-  testthat::expect_equal(survobj$data_name, "adtte")
+  expect_equal(survobj$data_name, "adtte")
 
   # no data_name error when there is no data_name
-  testthat::expect_error(rlang::inject(visR::estimate_KM(data = !!adtte, strata = "RACE")), NA)
+  expect_error(rlang::inject(visR::estimate_KM(data = !!adtte, strata = "RACE")), NA)
 })
 
-testthat::test_that("T6.5 The function adds the environment to the call", {
+test_that("T6.5 The function adds the environment to the call", {
   survobj <- visR::estimate_KM(data = adtte, strata = "SEX")
 
-  testthat::expect_true(inherits(attr(survobj$call, ".Environment"), "environment"))
+  expect_true(inherits(attr(survobj$call, ".Environment"), "environment"))
 })
 
 
 # Requirement T7 ---------------------------------------------------------------
 
-testthat::context("estimate_KM - T7. The function call supports traceability")
+context("estimate_KM - T7. The function call supports traceability")
 
-testthat::test_that("T7.1 The function updates .$data_name when magrittr pipe is used", {
+test_that("T7.1 The function updates .$data_name when magrittr pipe is used", {
   ## using .
   survobj_visR <-
     adtte %>%
     visR::estimate_KM(data = ., strata = "SEX")
-  testthat::expect_equal(survobj_visR[["data_name"]], "adtte")
+  expect_equal(survobj_visR[["data_name"]], "adtte")
 
   # without .
   survobj_visR <-
     adtte %>%
     visR::estimate_KM(strata = "SEX")
-  testthat::expect_equal(survobj_visR[["data_name"]], "adtte")
+  expect_equal(survobj_visR[["data_name"]], "adtte")
 })
 
-testthat::test_that("T7.2 The function prefixes the function call with survival when relying on the CDISC ADaM model", {
+test_that("T7.2 The function prefixes the function call with survival when relying on the CDISC ADaM model", {
   ## survival package
   survobj_visR <-
     adtte %>%
     visR::estimate_KM(data = ., strata = "SEX")
   call_visR <- as.list(rlang::quo_squash(survobj_visR[["call"]]))
 
-  testthat::expect_equal(call_visR[[1]], quote(survival::survfit))
+  expect_equal(call_visR[[1]], quote(survival::survfit))
 })
 
 # Requirement T8 ---------------------------------------------------------------
 
-testthat::context("estimate_KM - T8. Piped datasets still return accurate results")
+context("estimate_KM - T8. Piped datasets still return accurate results")
 
-testthat::test_that("T8.1 Piped datasets still return accurate results", {
+test_that("T8.1 Piped datasets still return accurate results", {
   estimate_KM <-
     adtte %>%
     dplyr::filter(SEX == "F", AGE < 60) %>%
@@ -453,7 +453,7 @@ testthat::test_that("T8.1 Piped datasets still return accurate results", {
     ) %>%
     survival::survfit0()
   vals_to_check <- names(survfit) %>% setdiff(c("strata", "call"))
-  testthat::expect_equal(unclass(survfit)[vals_to_check], unclass(estimate_KM)[vals_to_check])
+  expect_equal(unclass(survfit)[vals_to_check], unclass(estimate_KM)[vals_to_check])
 
   estimate_KM <-
     adtte[1:100, ] %>%
@@ -464,18 +464,18 @@ testthat::test_that("T8.1 Piped datasets still return accurate results", {
       data = adtte[1:100, ]
     ) %>%
     survival::survfit0()
-  testthat::expect_equal(unclass(survfit)[vals_to_check], unclass(estimate_KM)[vals_to_check])
+  expect_equal(unclass(survfit)[vals_to_check], unclass(estimate_KM)[vals_to_check])
 })
 
 # Requirement T9 ---------------------------------------------------------------
 
-testthat::context("estimate_KM - T9. The user can specify `formula` argument")
+context("estimate_KM - T9. The user can specify `formula` argument")
 
-testthat::test_that("T9.1 The `formula` argument returns the same results compared as implementing the CDISC ADaM model", {
+test_that("T9.1 The `formula` argument returns the same results compared as implementing the CDISC ADaM model", {
   # with CDISC data
   km1 <- visR::estimate_KM(data = adtte, strata = "SEX")
   km2 <- visR::estimate_KM(formula = survival::Surv(AVAL, 1 - CNSR) ~ SEX, data = adtte)
-  testthat::expect_equal(km1, km2)
+  expect_equal(km1, km2)
 
   # without CDISC data
   km1 <-
@@ -487,36 +487,36 @@ testthat::test_that("T9.1 The `formula` argument returns the same results compar
     visR::estimate_KM(strata = "trt")
   km2 <- visR::estimate_KM(data = survival::veteran, formula = survival::Surv(time, status) ~ trt)
   km1$call <- km2$call <- NULL
-  testthat::expect_equal(km1, km2)
+  expect_equal(km1, km2)
 })
 
-testthat::test_that("T9.2 The `formula` argument triggers error messages with incorrect function specification", {
-  testthat::expect_error(
+test_that("T9.2 The `formula` argument triggers error messages with incorrect function specification", {
+  expect_error(
     visR::estimate_KM(formula = Surv(AVAL, 1 - CNSR) ~ SEX, data = letters)
   )
-  testthat::expect_error(
+  expect_error(
     visR::estimate_KM(formula = letters, data = survival::lung)
   )
-  testthat::expect_error(
+  expect_error(
     visR::estimate_KM(formula = Surv(AVAL, 1 - CNSR) ~ SEX)
   )
 
-  testthat::expect_error(
+  expect_error(
     visR::estimate_KM(formula = Surv(AVAL, 1 - CNSR) ~ 1, data = letters)
   )
-  testthat::expect_error(
+  expect_error(
     visR::estimate_KM(formula = Surv(AVAL, 1 - CNSR) ~ 1)
   )
-  testthat::expect_error(
+  expect_error(
     visR::estimate_KM(formula = Surv(AVAL, 1 - CNSR) ~ NOT_A_VARIABLE, data = adtte)
   )
 })
 
-testthat::test_that("T9.3 The `formula` argument ignores the strata, CNSR and AVAL arguments.", {
+test_that("T9.3 The `formula` argument ignores the strata, CNSR and AVAL arguments.", {
   km1 <- visR::estimate_KM(data = adtte, strata = "SEX")
   km2 <- visR::estimate_KM(strata = "RACE", AVAL = "HELLO", CNSR = "CNSR", formula = Surv(AVAL, 1 - CNSR) ~ SEX, data = adtte)
   km1$call <- km2$call <- NULL
-  testthat::expect_equal(km1, km2)
+  expect_equal(km1, km2)
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-estimate_cuminc.R
+++ b/tests/testthat/test-estimate_cuminc.R
@@ -32,150 +32,150 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("estimate_cuminc - T1. The function accepts a `data.frame` `tibble` or `data.table`")
+context("estimate_cuminc - T1. The function accepts a `data.frame` `tibble` or `data.table`")
 
-testthat::test_that("T1.1 No error when `data` is of class `data.frame`", {
+test_that("T1.1 No error when `data` is of class `data.frame`", {
   data <- tidycmprsk::trial
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath"), NA
   )
 })
 
-testthat::test_that("T1.2 No error when `data` is of class `tibble`", {
+test_that("T1.2 No error when `data` is of class `tibble`", {
   data <- dplyr::as_tibble(tidycmprsk::trial)
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath"), NA
   )
 })
 
-testthat::test_that("T1.3 No error when `data` is of class `data.table`", {
+test_that("T1.3 No error when `data` is of class `data.table`", {
   if (nzchar(find.package("data.table"))) {
     data <- data.table::as.data.table(tidycmprsk::trial)
-    testthat::expect_error(
+    expect_error(
       visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath"), NA
     )
   }
 })
 
-testthat::test_that("T1.4 An error when `data` is of an unexpected class, eg `list`", {
+test_that("T1.4 An error when `data` is of an unexpected class, eg `list`", {
   data <- base::as.list(tidycmprsk::trial)
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath")
   )
 })
 
-testthat::test_that("T1.5 An error when `data` is NULL", {
-  testthat::expect_error(
+test_that("T1.5 An error when `data` is NULL", {
+  expect_error(
     visR::estimate_cuminc(data = NULL, CNSR = "death_cr", AVAL = "ttdeath")
   )
 })
 
 # Requirement T2 ----------------------------------------------------------
 
-testthat::context("estimate_cuminc - T2. The function relies on the presence of two numeric variables, specified through `AVAL` and `CNSR`, to be present in `data`")
+context("estimate_cuminc - T2. The function relies on the presence of two numeric variables, specified through `AVAL` and `CNSR`, to be present in `data`")
 
-testthat::test_that("T2.1 An error when colname specified through `AVAL` is not present in `data`", {
+test_that("T2.1 An error when colname specified through `AVAL` is not present in `data`", {
   data <- tidycmprsk::trial
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "test")
   )
 })
 
-testthat::test_that("T2.2 An error when colname specified through `AVAL` is not numeric", {
+test_that("T2.2 An error when colname specified through `AVAL` is not numeric", {
   data <- tidycmprsk::trial
   data[["ttdeath"]] <- as.character(data[["ttdeath"]])
 
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath")
   )
 })
 
-testthat::test_that("T2.3 No error when the colname specified through `AVAL` is not the proposed default", {
+test_that("T2.3 No error when the colname specified through `AVAL` is not the proposed default", {
   data <- tidycmprsk::trial
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath"), NA
   )
 })
 
-testthat::test_that("T2.4 An error when colname specified through `CNSR` is not present in `data`", {
+test_that("T2.4 An error when colname specified through `CNSR` is not present in `data`", {
   data <- tidycmprsk::trial
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "test", AVAL = "ttdeath")
   )
 })
 
-testthat::test_that("T2.5 An error when colname specified through `CNSR` is not a factor", {
+test_that("T2.5 An error when colname specified through `CNSR` is not a factor", {
   data <- tidycmprsk::trial
   data[["death_cr"]] <- as.numeric(data[["death_cr"]])
 
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath")
   )
 })
 
-testthat::test_that("T2.6 No error when the colname specified through `CNSR` is not the proposed default", {
+test_that("T2.6 No error when the colname specified through `CNSR` is not the proposed default", {
   data <- tidycmprsk::trial
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath"), NA
   )
 })
 
 # Requirement T3 ----------------------------------------------------------
 
-testthat::context("estimate_cuminc - T3. The user can specify strata")
+context("estimate_cuminc - T3. The user can specify strata")
 
-testthat::test_that("T3.1 An error when the columns, specifying the strata are not available in `data`", {
+test_that("T3.1 An error when the columns, specifying the strata are not available in `data`", {
   data <- tidycmprsk::trial
   data[["trt"]] <- NULL
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = "trt")
   )
 })
 
-testthat::test_that("T3.2 No error when strata is NULL", {
+test_that("T3.2 No error when strata is NULL", {
   data <- tidycmprsk::trial
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = NULL), NA
   )
 })
 
-testthat::test_that("T3.3 An error when `strata` is not part of `data`", {
+test_that("T3.3 An error when `strata` is not part of `data`", {
   data <- tidycmprsk::trial
   data[["trt"]] <- NULL
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = "trt")
   )
 })
 
 # Requirement T4 ----------------------------------------------------------
 
-testthat::context("estimate_cuminc - T4. The user can specify conf.int")
+context("estimate_cuminc - T4. The user can specify conf.int")
 
-testthat::test_that("T4.1 An error when the conf.int is not numeric", {
+test_that("T4.1 An error when the conf.int is not numeric", {
   data <- tidycmprsk::trial
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = "trt", conf.int = "blah")
   )
 })
 
-testthat::test_that("T4.2 An error when the conf.int is numeric but not between 0 and 1", {
+test_that("T4.2 An error when the conf.int is numeric but not between 0 and 1", {
   data <- tidycmprsk::trial
-  testthat::expect_error(
+  expect_error(
     visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = "trt", conf.int = 2)
   )
 })
 
-testthat::test_that("T4.3 No error when the conf.int is numeric and between 0 and 1", {
+test_that("T4.3 No error when the conf.int is numeric and between 0 and 1", {
   data <- tidycmprsk::trial
   conf <- 0.60
-  testthat::expect_error(visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = "trt", conf.int = conf), NA)
+  expect_error(visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = "trt", conf.int = conf), NA)
 })
 
-testthat::test_that("T4.4 A correct value for conf.int results in the resulting", {
+test_that("T4.4 A correct value for conf.int results in the resulting", {
   data <- tidycmprsk::trial
   conf <- 0.60
   cuminc <- visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = "trt", conf.int = conf)
-  testthat::expect_equal(conf, cuminc[["conf.level"]])
+  expect_equal(conf, cuminc[["conf.level"]])
 })
 
 
@@ -184,9 +184,9 @@ testthat::test_that("T4.4 A correct value for conf.int results in the resulting"
 
 # Requirement T5 ----------------------------------------------------------
 
-testthat::context("estimate_cuminc - T5. The function removes all rows with NA values inside any of the strata, CNSR or AVAL")
+context("estimate_cuminc - T5. The function removes all rows with NA values inside any of the strata, CNSR or AVAL")
 
-testthat::test_that("T5.1 The function removes all rows with NA values inside any of the strata, CNSR or AVAL", {
+test_that("T5.1 The function removes all rows with NA values inside any of the strata, CNSR or AVAL", {
   data <- tidycmprsk::trial
   data[1:10, "trt"] <- NA
   data[11:20, "ttdeath"] <- NA
@@ -199,14 +199,14 @@ testthat::test_that("T5.1 The function removes all rows with NA values inside an
   data <- tidyr::drop_na(data, trt, ttdeath, death_cr)
   cumobjNA <- visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = "trt")
 
-  testthat::expect_equal(cumobjNA, cumobj)
+  expect_equal(cumobjNA, cumobj)
 })
 
 # Requirement T6 ----------------------------------------------------------
 
-testthat::context("estimate_cuminc - T6. The function does not alter the calculation of tidycmprsk::cuminc")
+context("estimate_cuminc - T6. The function does not alter the calculation of tidycmprsk::cuminc")
 
-testthat::test_that("T6.1 The function gives the same results as tidycmprsk::cuminc", {
+test_that("T6.1 The function gives the same results as tidycmprsk::cuminc", {
   data <- tidycmprsk::trial
   cumvisr <- visR::estimate_cuminc(data = data, CNSR = "death_cr", AVAL = "ttdeath", strata = "trt")
   cumori <- tidycmprsk::cuminc(
@@ -214,7 +214,7 @@ testthat::test_that("T6.1 The function gives the same results as tidycmprsk::cum
     data = data
   )
 
-  testthat::expect_equal(cumvisr, cumori)
+  expect_equal(cumvisr, cumori)
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-get_COX_HR.R
+++ b/tests/testthat/test-get_COX_HR.R
@@ -16,48 +16,48 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("get_COX_HR - T1. The function accepts a `survfit` object")
+context("get_COX_HR - T1. The function accepts a `survfit` object")
 
-testthat::test_that("T1.1 No error when the input is a `survfit` object", {
+test_that("T1.1 No error when the input is a `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_COX_HR(survfit_object), NA)
+  expect_error(visR::get_COX_HR(survfit_object), NA)
 })
 
-testthat::test_that("T1.2 An error when the input is a non-`survfit` object", {
+test_that("T1.2 An error when the input is a non-`survfit` object", {
   survfit_object <- as.list("blah")
-  testthat::expect_error(visR::get_COX_HR(survfit_object))
+  expect_error(visR::get_COX_HR(survfit_object))
 })
 
-testthat::test_that("T1.3 An error when the input is NULL", {
+test_that("T1.3 An error when the input is NULL", {
   survfit_object <- NULL
-  testthat::expect_error(visR::get_COX_HR(survfit_object))
+  expect_error(visR::get_COX_HR(survfit_object))
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("get_COX_HR - T1. The function accepts a `survfit` object")
+context("get_COX_HR - T1. The function accepts a `survfit` object")
 
-testthat::test_that("T2.1 No error when the update_formula argument is a `formula`", {
+test_that("T2.1 No error when the update_formula argument is a `formula`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   formula <- ". ~ . + SEX"
-  testthat::expect_error(visR::get_COX_HR(survfit_object,
+  expect_error(visR::get_COX_HR(survfit_object,
     update_formula = formula
   ), NA)
 })
 
-testthat::test_that("T2.2 An error when the update_formula argument is not a `formula`", {
+test_that("T2.2 An error when the update_formula argument is not a `formula`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   formula <- as.list("&?")
-  testthat::expect_error(visR::get_COX_HR(survfit_object,
+  expect_error(visR::get_COX_HR(survfit_object,
     update_formula = formula
   ))
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("get_COX_HR - T3. The function calculates the COX Hazard Ratio")
+context("get_COX_HR - T3. The function calculates the COX Hazard Ratio")
 
-testthat::test_that("T3.1 No error when the update_formula argument is a `formula`", {
+test_that("T3.1 No error when the update_formula argument is a `formula`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   formula <- ". ~ . + SEX"
   tidy_coxph_visR <- visR::get_COX_HR(survfit_object, update_formula = formula)
@@ -68,15 +68,15 @@ testthat::test_that("T3.1 No error when the update_formula argument is a `formul
   )
   tidy_coxph_traditional <- as.data.frame(broom::tidy(coxph))
 
-  testthat::expect_equal(tidy_coxph_traditional, tidy_coxph_visR)
+  expect_equal(tidy_coxph_traditional, tidy_coxph_visR)
 })
 
-testthat::test_that("T3.2 The function returns a data.frame", {
+test_that("T3.2 The function returns a data.frame", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   formula <- ". ~ . + SEX"
   tidy_coxph_visR <- visR::get_COX_HR(survfit_object, update_formula = formula)
 
-  testthat::expect_true(inherits(tidy_coxph_visR, "data.frame"))
+  expect_true(inherits(tidy_coxph_visR, "data.frame"))
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-get_attrition.R
+++ b/tests/testthat/test-get_attrition.R
@@ -38,11 +38,11 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("get_attrition - T1. The function accepts a `data.frame` `tibble` or `data.table`")
+context("get_attrition - T1. The function accepts a `data.frame` `tibble` or `data.table`")
 
-testthat::test_that("T1.1 No error when `data` is of class `data.frame`", {
+test_that("T1.1 No error when `data` is of class `data.frame`", {
   data <- adtte
-  testthat::expect_error(
+  expect_error(
     visR::get_attrition(
       data = data,
       criteria_descriptions = c(
@@ -55,9 +55,9 @@ testthat::test_that("T1.1 No error when `data` is of class `data.frame`", {
   )
 })
 
-testthat::test_that("T1.2 No error when `data` is of class `tibble`", {
+test_that("T1.2 No error when `data` is of class `tibble`", {
   data <- dplyr::as_tibble(adtte)
-  testthat::expect_error(
+  expect_error(
     visR::get_attrition(
       data = data,
       criteria_descriptions = c(
@@ -70,10 +70,10 @@ testthat::test_that("T1.2 No error when `data` is of class `tibble`", {
   )
 })
 
-testthat::test_that("T1.3 No error when `data` is of class `data.table`", {
+test_that("T1.3 No error when `data` is of class `data.table`", {
   if (nzchar(find.package("data.table"))) {
     data <- data.table::as.data.table(adtte)
-    testthat::expect_error(
+    expect_error(
       visR::get_attrition(
         data = data,
         criteria_descriptions = c(
@@ -87,9 +87,9 @@ testthat::test_that("T1.3 No error when `data` is of class `data.table`", {
   }
 })
 
-testthat::test_that("T1.4 An error when `data` is of an unexpected class, eg `list`", {
+test_that("T1.4 An error when `data` is of an unexpected class, eg `list`", {
   data <- base::as.list(adtte)
-  testthat::expect_error(
+  expect_error(
     visR::get_attrition(
       data = data,
       criteria_descriptions = c(
@@ -102,8 +102,8 @@ testthat::test_that("T1.4 An error when `data` is of an unexpected class, eg `li
   )
 })
 
-testthat::test_that("T1.5 An error when `data` is NULL", {
-  testthat::expect_error(
+test_that("T1.5 An error when `data` is NULL", {
+  expect_error(
     visR::get_attrition(
       data = NULL,
       criteria_descriptions = c(
@@ -116,8 +116,8 @@ testthat::test_that("T1.5 An error when `data` is NULL", {
   )
 })
 
-testthat::test_that("T1.6 An error when `data` does not exist in the global environment", {
-  testthat::expect_error(
+test_that("T1.6 An error when `data` does not exist in the global environment", {
+  expect_error(
     visR::get_attrition(
       data = blah,
       criteria_descriptions = c(
@@ -132,10 +132,10 @@ testthat::test_that("T1.6 An error when `data` does not exist in the global envi
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("get_attrition - T2. The function correctly handles arguments")
+context("get_attrition - T2. The function correctly handles arguments")
 
-testthat::test_that("T2.1 No error when `criteria_descriptions` is a character vector", {
-  testthat::expect_error(
+test_that("T2.1 No error when `criteria_descriptions` is a character vector", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = c(
@@ -148,8 +148,8 @@ testthat::test_that("T2.1 No error when `criteria_descriptions` is a character v
   )
 })
 
-testthat::test_that("T2.2 An error when `criteria_descriptions` is not a character vector", {
-  testthat::expect_error(
+test_that("T2.2 An error when `criteria_descriptions` is not a character vector", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = "BLAH",
@@ -159,8 +159,8 @@ testthat::test_that("T2.2 An error when `criteria_descriptions` is not a charact
   )
 })
 
-testthat::test_that("T2.3 An error when `criteria_descriptions` is NULL", {
-  testthat::expect_error(
+test_that("T2.3 An error when `criteria_descriptions` is NULL", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = NULL,
@@ -170,8 +170,8 @@ testthat::test_that("T2.3 An error when `criteria_descriptions` is NULL", {
   )
 })
 
-testthat::test_that("T2.4 No error when `criteria_conditions` is a character vector", {
-  testthat::expect_error(
+test_that("T2.4 No error when `criteria_conditions` is a character vector", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = c(
@@ -184,8 +184,8 @@ testthat::test_that("T2.4 No error when `criteria_conditions` is a character vec
   )
 })
 
-testthat::test_that("T2.5 An error when `criteria_conditions` is not a character vector", {
-  testthat::expect_error(
+test_that("T2.5 An error when `criteria_conditions` is not a character vector", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = c(
@@ -198,8 +198,8 @@ testthat::test_that("T2.5 An error when `criteria_conditions` is not a character
   )
 })
 
-testthat::test_that("T2.6 An error when `criteria_conditions` is NULL", {
-  testthat::expect_error(
+test_that("T2.6 An error when `criteria_conditions` is NULL", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = c(
@@ -213,8 +213,8 @@ testthat::test_that("T2.6 An error when `criteria_conditions` is NULL", {
 })
 
 
-testthat::test_that("T2.7 No error when `subject_column_name` is a string", {
-  testthat::expect_error(
+test_that("T2.7 No error when `subject_column_name` is a string", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = c(
@@ -227,8 +227,8 @@ testthat::test_that("T2.7 No error when `subject_column_name` is a string", {
   )
 })
 
-testthat::test_that("T2.8 An error when `subject_column_name` is not a character vector", {
-  testthat::expect_error(
+test_that("T2.8 An error when `subject_column_name` is not a character vector", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = c(
@@ -241,8 +241,8 @@ testthat::test_that("T2.8 An error when `subject_column_name` is not a character
   )
 })
 
-testthat::test_that("T2.9 An error when `subject_column_name` is NULL", {
-  testthat::expect_error(
+test_that("T2.9 An error when `subject_column_name` is NULL", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = c(
@@ -255,8 +255,8 @@ testthat::test_that("T2.9 An error when `subject_column_name` is NULL", {
   )
 })
 
-testthat::test_that("T2.10 An error when `subject_column_name` is missing as a column in `data`", {
-  testthat::expect_error(
+test_that("T2.10 An error when `subject_column_name` is missing as a column in `data`", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = c(
@@ -269,8 +269,8 @@ testthat::test_that("T2.10 An error when `subject_column_name` is missing as a c
   )
 })
 
-testthat::test_that("T2.11 An error when `criteria_descriptions` and `criteria_descriptions` do not have the same length", {
-  testthat::expect_error(
+test_that("T2.11 An error when `criteria_descriptions` and `criteria_descriptions` do not have the same length", {
+  expect_error(
     visR::get_attrition(
       data = adtte,
       criteria_descriptions = "BLAH",
@@ -282,11 +282,11 @@ testthat::test_that("T2.11 An error when `criteria_descriptions` and `criteria_d
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("get_attrition - T3. The returned object is of correct shape")
+context("get_attrition - T3. The returned object is of correct shape")
 
-testthat::test_that("T3.1 Correct number of rows in the data.frame with `criteria_conditions`+1 rows", {
+test_that("T3.1 Correct number of rows in the data.frame with `criteria_conditions`+1 rows", {
   cdesc <- c("1. Placebo Group", "2. Be 75 years of age or older.")
-  testthat::expect_equal(
+  expect_equal(
     nrow(visR::get_attrition(
       data = adtte,
       criteria_descriptions = cdesc,
@@ -296,8 +296,8 @@ testthat::test_that("T3.1 Correct number of rows in the data.frame with `criteri
   )
 })
 
-testthat::test_that("T3.2 Correct number of columns in the data.frame", {
-  testthat::expect_equal(
+test_that("T3.2 Correct number of columns in the data.frame", {
+  expect_equal(
     ncol(visR::get_attrition(
       data = adtte,
       criteria_descriptions = c(
@@ -312,9 +312,9 @@ testthat::test_that("T3.2 Correct number of columns in the data.frame", {
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("get_attrition - T4. The function filters correctly when provided a vector of single filters")
+context("get_attrition - T4. The function filters correctly when provided a vector of single filters")
 
-testthat::test_that("T4.1 Correct filtering string column", {
+test_that("T4.1 Correct filtering string column", {
   ninit <- length(unique(adtte$USUBJID))
   filtered_data <- adtte %>% dplyr::filter(TRTP == "Placebo")
 
@@ -324,18 +324,18 @@ testthat::test_that("T4.1 Correct filtering string column", {
     subject_column_name = "USUBJID"
   )
 
-  testthat::expect_equal(
+  expect_equal(
     outdf$`Remaining N`[length(outdf$`Remaining N`)],
     length(unique(filtered_data$USUBJID))
   )
 
-  testthat::expect_equal(
+  expect_equal(
     outdf$`Excluded N`[length(outdf$`Excluded N`)],
     ninit - length(unique(filtered_data$USUBJID))
   )
 })
 
-testthat::test_that("T4.2 Correct filtering integer column", {
+test_that("T4.2 Correct filtering integer column", {
   ninit <- length(unique(adtte$USUBJID))
   filtered_data <- adtte %>% dplyr::filter(AGE >= 75)
 
@@ -345,18 +345,18 @@ testthat::test_that("T4.2 Correct filtering integer column", {
     subject_column_name = "USUBJID"
   )
 
-  testthat::expect_equal(
+  expect_equal(
     outdf$`Remaining N`[length(outdf$`Remaining N`)],
     length(unique(filtered_data$USUBJID))
   )
 
-  testthat::expect_equal(
+  expect_equal(
     outdf$`Excluded N`[length(outdf$`Excluded N`)],
     ninit - length(unique(filtered_data$USUBJID))
   )
 })
 
-testthat::test_that("T4.3 Correct filtering factor column", {
+test_that("T4.3 Correct filtering factor column", {
   data <- adtte %>% dplyr::mutate(AGEGR1 = factor(AGEGR1))
   ninit <- length(unique(data$USUBJID))
   filtered_data <- adtte %>% dplyr::filter(AGEGR1 == "< 65")
@@ -368,13 +368,13 @@ testthat::test_that("T4.3 Correct filtering factor column", {
   )
 
   # test remaining n at end of dataframe
-  testthat::expect_equal(
+  expect_equal(
     outdf$`Remaining N`[length(outdf$`Remaining N`)],
     length(unique(filtered_data$USUBJID))
   )
 
   # test excluded n at end of dataframe
-  testthat::expect_equal(
+  expect_equal(
     outdf$`Excluded N`[length(outdf$`Excluded N`)],
     ninit - length(unique(filtered_data$USUBJID))
   )
@@ -382,9 +382,9 @@ testthat::test_that("T4.3 Correct filtering factor column", {
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("get_attrition - T5. The function filters correctly when provided a vector of single filters")
+context("get_attrition - T5. The function filters correctly when provided a vector of single filters")
 
-testthat::test_that("T5.1 Correct filtering using a combined filter containing logical `and` (`&`)", {
+test_that("T5.1 Correct filtering using a combined filter containing logical `and` (`&`)", {
   ninit <- length(unique(adtte$USUBJID))
   outdf1 <- visR::get_attrition(
     adtte,
@@ -397,13 +397,13 @@ testthat::test_that("T5.1 Correct filtering using a combined filter containing l
     dplyr::filter(SEX == "M")
 
   # test remaining n at end of data.frame
-  testthat::expect_equal(
+  expect_equal(
     outdf1$`Remaining N`[length(outdf1$`Remaining N`)],
     length(unique(filtered_data$USUBJID))
   )
 
   # test excluded n at end of data.frame
-  testthat::expect_equal(
+  expect_equal(
     outdf1$`Excluded N`[length(outdf1$`Excluded N`)],
     ninit - length(unique(filtered_data$USUBJID))
   )
@@ -422,13 +422,13 @@ testthat::test_that("T5.1 Correct filtering using a combined filter containing l
     dplyr::filter(TRTP == "Placebo")
 
   # test remaining n at end of data.frame
-  testthat::expect_equal(
+  expect_equal(
     outdf2$`Remaining N`[length(outdf2$`Remaining N`)],
     length(unique(filtered_data$USUBJID))
   )
 })
 
-testthat::test_that("T5.2 Correct filtering using a combined filter containing logical `or` (`|`)", {
+test_that("T5.2 Correct filtering using a combined filter containing logical `or` (`|`)", {
   ninit <- length(unique(adtte$USUBJID))
   outdf1 <- visR::get_attrition(
     adtte,
@@ -442,13 +442,13 @@ testthat::test_that("T5.2 Correct filtering using a combined filter containing l
 
   # test remaining n at end of data.frame
 
-  testthat::expect_equal(
+  expect_equal(
     outdf1$`Remaining N`[length(outdf1$`Remaining N`)],
     length(unique(filtered_data$USUBJID))
   )
 
   # test excluded n at end of data.frame
-  testthat::expect_equal(
+  expect_equal(
     outdf1$`Excluded N`[length(outdf1$`Excluded N`)],
     ninit - length(unique(filtered_data$USUBJID))
   )
@@ -470,7 +470,7 @@ testthat::test_that("T5.2 Correct filtering using a combined filter containing l
     dplyr::filter(RACE == "WHITE")
 
   # test remaining n at end of data.frame
-  testthat::expect_equal(
+  expect_equal(
     outdf2$`Remaining N`[length(outdf2$`Remaining N`)],
     length(unique(filtered_data$USUBJID))
   )
@@ -478,9 +478,9 @@ testthat::test_that("T5.2 Correct filtering using a combined filter containing l
 
 # Requirement T6 ---------------------------------------------------------------
 
-testthat::context("get_attrition - T6. The returned object is of correct class")
+context("get_attrition - T6. The returned object is of correct class")
 
-testthat::test_that("T6.1 The object is of class `data.frame`", {
+test_that("T6.1 The object is of class `data.frame`", {
   outdf <- visR::get_attrition(
     adtte,
     criteria_descriptions = c(
@@ -491,10 +491,10 @@ testthat::test_that("T6.1 The object is of class `data.frame`", {
     subject_column_name = "USUBJID"
   )
 
-  testthat::expect_s3_class(outdf, "data.frame")
+  expect_s3_class(outdf, "data.frame")
 })
 
-testthat::test_that("T6.2 The object is of class `attrition`", {
+test_that("T6.2 The object is of class `attrition`", {
   outdf <- visR::get_attrition(
     adtte,
     criteria_descriptions = c(
@@ -505,7 +505,7 @@ testthat::test_that("T6.2 The object is of class `attrition`", {
     subject_column_name = "USUBJID"
   )
 
-  testthat::expect_s3_class(outdf, "attrition")
+  expect_s3_class(outdf, "attrition")
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-get_pvalue.R
+++ b/tests/testthat/test-get_pvalue.R
@@ -37,63 +37,63 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("get_pvalue - T1. The function accepts a `survfit` object")
+context("get_pvalue - T1. The function accepts a `survfit` object")
 
-testthat::test_that("T1.1. No error when a `survfit` object is passed to the function with at least 2 strata", {
+test_that("T1.1. No error when a `survfit` object is passed to the function with at least 2 strata", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_pvalue(survfit_object), NA)
+  expect_error(visR::get_pvalue(survfit_object), NA)
 })
 
-testthat::test_that("TT1.2 An error when a `survfit` object is passed to the function with 1 strata", {
+test_that("TT1.2 An error when a `survfit` object is passed to the function with 1 strata", {
   survfit_object <- visR::estimate_KM(adtte, strata = "STUDYID")
-  testthat::expect_error(visR::get_pvalue(survfit_object))
+  expect_error(visR::get_pvalue(survfit_object))
 })
 
-testthat::test_that("TT1.3 An error when a non-`survfit` object is passed to the function", {
+test_that("TT1.3 An error when a non-`survfit` object is passed to the function", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   class(survfit_object) <- "blah"
-  testthat::expect_error(visR::get_pvalue(survfit_object))
+  expect_error(visR::get_pvalue(survfit_object))
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T2. The functions tests the null hypothesis of no difference between two or more survival curves using the G-rho family of tests")
+context("get_pvalue - T2. The functions tests the null hypothesis of no difference between two or more survival curves using the G-rho family of tests")
 
-testthat::test_that("T2.1 The function supports the Log-Rank test by setting ptype = 'Log-Rank'", {
+test_that("T2.1 The function supports the Log-Rank test by setting ptype = 'Log-Rank'", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_equal(
+  expect_equal(
     visR::get_pvalue(survfit_object, ptype = "Log-Rank"),
     get_pvalue_ref1
   )
 })
 
-testthat::test_that("T2.2 The function supports the Wilcoxon test by setting ptype = 'Wilcoxon'", {
+test_that("T2.2 The function supports the Wilcoxon test by setting ptype = 'Wilcoxon'", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_equal(
+  expect_equal(
     visR::get_pvalue(survfit_object, ptype = "Wilcoxon"),
     get_pvalue_ref2
   )
 })
 
-testthat::test_that("T2.3 The function supports the Tarone-Ware test by setting ptype = 'Tarone-Ware'", {
+test_that("T2.3 The function supports the Tarone-Ware test by setting ptype = 'Tarone-Ware'", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_equal(
+  expect_equal(
     visR::get_pvalue(survfit_object, ptype = "Tarone-Ware"),
     get_pvalue_ref3
   )
 })
 
-testthat::test_that("T2.4 The function calculates the default ptype when ptype = 'All'", {
+test_that("T2.4 The function calculates the default ptype when ptype = 'All'", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_equal(
+  expect_equal(
     visR::get_pvalue(survfit_object, ptype = "All"),
     get_pvalue_ref[1:3, ]
   )
 })
 
-testthat::test_that("T2.5 The function supports the use of a custom `rho` in the calculation", {
+test_that("T2.5 The function supports the use of a custom `rho` in the calculation", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_equal(
+  expect_equal(
     visR::get_pvalue(survfit_object,
       ptype = "Custom",
       rho = 2.4
@@ -102,9 +102,9 @@ testthat::test_that("T2.5 The function supports the use of a custom `rho` in the
   )
 })
 
-testthat::test_that("T2.6 The function supports the use of a custom `rho` in the calculation when ptype = `All`", {
+test_that("T2.6 The function supports the use of a custom `rho` in the calculation when ptype = `All`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_equal(
+  expect_equal(
     visR::get_pvalue(survfit_object,
       ptype = "All",
       rho = 2.4
@@ -113,9 +113,9 @@ testthat::test_that("T2.6 The function supports the use of a custom `rho` in the
   )
 })
 
-testthat::test_that("T2.7 The function accepts a vector for ptype, containing multiple requests eg c('Tarone-Ware', 'Log-Rank', 'Custom')", {
+test_that("T2.7 The function accepts a vector for ptype, containing multiple requests eg c('Tarone-Ware', 'Log-Rank', 'Custom')", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_equal(
+  expect_equal(
     visR::get_pvalue(survfit_object,
       ptype = c(
         "Log-Rank",
@@ -128,47 +128,47 @@ testthat::test_that("T2.7 The function accepts a vector for ptype, containing mu
   )
 })
 
-testthat::test_that("T2.8 An error when ptype includes 'Custom' but rho is not specified", {
+test_that("T2.8 An error when ptype includes 'Custom' but rho is not specified", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_pvalue(survfit_object, ptype = "Custom"))
+  expect_error(visR::get_pvalue(survfit_object, ptype = "Custom"))
 })
 
-testthat::test_that("T2.9 An error when a non-supported ptype is requested", {
+test_that("T2.9 An error when a non-supported ptype is requested", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_pvalue(survfit_object, ptype = "blah"))
+  expect_error(visR::get_pvalue(survfit_object, ptype = "blah"))
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T3. The functions returns the results of the test statistic, degrees of freedom and the p-value of the null hypothesis when requested")
+context("get_pvalue - T3. The functions returns the results of the test statistic, degrees of freedom and the p-value of the null hypothesis when requested")
 
-testthat::test_that("T3.1 No error when the test statistic is requested", {
+test_that("T3.1 No error when the test statistic is requested", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_pvalue(survfit_object, statlist = "test"), NA)
+  expect_error(visR::get_pvalue(survfit_object, statlist = "test"), NA)
 })
 
-testthat::test_that("T3.2 No error when the degrees of freedom is requested", {
+test_that("T3.2 No error when the degrees of freedom is requested", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_pvalue(survfit_object, statlist = "df"), NA)
+  expect_error(visR::get_pvalue(survfit_object, statlist = "df"), NA)
 })
 
-testthat::test_that("T3.3 No error when the p-value is requested", {
+test_that("T3.3 No error when the p-value is requested", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_pvalue(survfit_object, statlist = "pvalue"), NA)
+  expect_error(visR::get_pvalue(survfit_object, statlist = "pvalue"), NA)
 })
 
-testthat::test_that("T3.4 An error when an unsupported argument is used in statlist", {
+test_that("T3.4 An error when an unsupported argument is used in statlist", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_pvalue(survfit_object, statlist = "blah"))
+  expect_error(visR::get_pvalue(survfit_object, statlist = "blah"))
 })
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T4. The output object provides the requested information")
+context("get_pvalue - T4. The output object provides the requested information")
 
-testthat::test_that("T4.1 The output object is a data.frame", {
+test_that("T4.1 The output object is a data.frame", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_identical(
+  expect_identical(
     class(visR::get_pvalue(survfit_object,
       statlist = "test"
     )),
@@ -176,9 +176,9 @@ testthat::test_that("T4.1 The output object is a data.frame", {
   )
 })
 
-testthat::test_that("T4.2 The summary statistics are available via the columns of the output object", {
+test_that("T4.2 The summary statistics are available via the columns of the output object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_identical(
+  expect_identical(
     colnames(visR::get_pvalue(survfit_object,
       statlist = c("test", "df")
     )),
@@ -186,16 +186,16 @@ testthat::test_that("T4.2 The summary statistics are available via the columns o
   )
 })
 
-testthat::test_that("T4.3 Each test statistic and associated calculations are available via the rows of the output object", {
+test_that("T4.3 Each test statistic and associated calculations are available via the rows of the output object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_equal(nrow(visR::get_pvalue(survfit_object,
+  expect_equal(nrow(visR::get_pvalue(survfit_object,
     statlist = c("test", "df")
   )), 3)
 })
 
-testthat::test_that("T4.4 The statistical tests are ordered in line with the order defined in ptype", {
+test_that("T4.4 The statistical tests are ordered in line with the order defined in ptype", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_identical(
+  expect_identical(
     visR::get_pvalue(survfit_object,
       ptype = c("Wilcoxon", "Log-Rank")
     )[, 1],
@@ -203,9 +203,9 @@ testthat::test_that("T4.4 The statistical tests are ordered in line with the ord
   )
 })
 
-testthat::test_that("T4.5 The associated calculations of the statistical tests are ordered in line with the order defined in the statlist", {
+test_that("T4.5 The associated calculations of the statistical tests are ordered in line with the order defined in the statlist", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_identical(
+  expect_identical(
     colnames(visR::get_pvalue(survfit_object,
       statlist = c("df", "test")
     )),
@@ -213,14 +213,14 @@ testthat::test_that("T4.5 The associated calculations of the statistical tests a
   )
 })
 
-testthat::test_that("T4.6 The Chisq statistic has the same precision as the pvalue", {
+test_that("T4.6 The Chisq statistic has the same precision as the pvalue", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   totest <- visR::get_pvalue(survfit_object, statlist = c("Chisq", "pvalue"))
 
   pvals_nchar_after_dot <- gsub(".+?\\.", "", totest[["p-value"]]) %>% nchar()
   chisq_nchar_after_dot <- gsub(".+?\\.", "", totest[["Chisq"]]) %>% nchar()
 
-  testthat::expect_identical(pvals_nchar_after_dot, chisq_nchar_after_dot)
+  expect_identical(pvals_nchar_after_dot, chisq_nchar_after_dot)
 
   survfit_object <- visR::estimate_KM(adtte, strata = "SEX")
   totest <- visR::get_pvalue(survfit_object, statlist = c("Chisq", "pvalue"))
@@ -228,14 +228,14 @@ testthat::test_that("T4.6 The Chisq statistic has the same precision as the pval
   pvals_nchar_after_dot <- gsub(".+?\\.", "", totest[["p-value"]]) %>% nchar()
   chisq_nchar_after_dot <- gsub(".+?\\.", "", totest[["Chisq"]]) %>% nchar()
 
-  testthat::expect_identical(pvals_nchar_after_dot, chisq_nchar_after_dot)
+  expect_identical(pvals_nchar_after_dot, chisq_nchar_after_dot)
 })
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T5. Piped datasets still return accurate results")
+context("get_pvalue - T5. Piped datasets still return accurate results")
 
-testthat::test_that("T5.1 P-values are accurate when a filtered data frame is piped", {
+test_that("T5.1 P-values are accurate when a filtered data frame is piped", {
 
   # testing the p-value is correct when filtered data is piped to estimate_KM()
   survfit_p <-
@@ -255,14 +255,14 @@ testthat::test_that("T5.1 P-values are accurate when a filtered data frame is pi
       pchisq(.$chisq, length(.$n) - 1, lower.tail = FALSE)
     } %>%
     visR:::.pvalformat()
-  testthat::expect_equal(survfit_p, survdiff_p)
+  expect_equal(survfit_p, survdiff_p)
 })
 
 # Requirement T6 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T6. Function works with `survival::survfit()` objects")
+context("get_pvalue - T6. Function works with `survival::survfit()` objects")
 
-testthat::test_that("T6.1 Function works with `survival::survfit()` objects", {
+test_that("T6.1 Function works with `survival::survfit()` objects", {
   expect_error(
     survival::survfit(survival::Surv(time, status) ~ sex, data = survival::lung) %>%
       get_pvalue(),
@@ -270,7 +270,7 @@ testthat::test_that("T6.1 Function works with `survival::survfit()` objects", {
   )
 })
 
-testthat::test_that("T6.2 Function messages users appropriately when data is piped, and p-value cannot be calculated", {
+test_that("T6.2 Function messages users appropriately when data is piped, and p-value cannot be calculated", {
   expect_error(
     survival::lung %>%
       survfit(Surv(time, status) ~ sex, data = .) %>%

--- a/tests/testthat/test-get_quantile.R
+++ b/tests/testthat/test-get_quantile.R
@@ -29,90 +29,90 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("get_pvalue - T1. The function accepts a `survfit` object")
+context("get_pvalue - T1. The function accepts a `survfit` object")
 
-testthat::test_that("T1.1 No error when a `survfit` object is passed to the function with at least 2 strata", {
+test_that("T1.1 No error when a `survfit` object is passed to the function with at least 2 strata", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_quantile(survfit_object), NA)
+  expect_error(visR::get_quantile(survfit_object), NA)
 })
 
-testthat::test_that("T1.2 An error when a `survfit` object is passed to the function with 1 strata", {
+test_that("T1.2 An error when a `survfit` object is passed to the function with 1 strata", {
   survfit_object <- visR::estimate_KM(adtte, strata = NULL)
-  testthat::expect_error(visR::get_quantile(survfit_object), NA)
+  expect_error(visR::get_quantile(survfit_object), NA)
 })
 
-testthat::test_that("T1.3 An error when a non-`survfit` object is passed to the function", {
-  testthat::expect_error(visR::get_quantile(adtte))
+test_that("T1.3 An error when a non-`survfit` object is passed to the function", {
+  expect_error(visR::get_quantile(adtte))
 })
 
-testthat::test_that("T1.4 An error when `survfit_object` does not exist in the global environment", {
-  testthat::expect_error(blah %>% visR::get_quantile())
-  testthat::expect_error(visR::get_quantile(survfit_object = blah))
+test_that("T1.4 An error when `survfit_object` does not exist in the global environment", {
+  expect_error(blah %>% visR::get_quantile())
+  expect_error(visR::get_quantile(survfit_object = blah))
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T2. The function accepts a tolerance limit")
+context("get_pvalue - T2. The function accepts a tolerance limit")
 
-testthat::test_that("T2.1 An error when the tolerance is not numeric", {
+test_that("T2.1 An error when the tolerance is not numeric", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_quantile(survfit_object, tolerance = "blah"))
+  expect_error(visR::get_quantile(survfit_object, tolerance = "blah"))
 })
 
-testthat::test_that("T2.2 No error when the tolerance is numeric", {
+test_that("T2.2 No error when the tolerance is numeric", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_quantile(survfit_object,
+  expect_error(visR::get_quantile(survfit_object,
     tolerance = 0.000000000001
   ), NA)
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T3. The function accepts a numeric vector specifying the probabilities")
+context("get_pvalue - T3. The function accepts a numeric vector specifying the probabilities")
 
-testthat::test_that("T3.1 No error when the probability vector is numeric and contains values below or equal to 1", {
+test_that("T3.1 No error when the probability vector is numeric and contains values below or equal to 1", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_quantile(survfit_object,
+  expect_error(visR::get_quantile(survfit_object,
     probs = c(0.50, 0.10)
   ), NA)
 })
 
-testthat::test_that("T3.2 An error when the probabilities are not numeric", {
+test_that("T3.2 An error when the probabilities are not numeric", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_quantile(survfit_object, probs = "blah"))
+  expect_error(visR::get_quantile(survfit_object, probs = "blah"))
 })
 
-testthat::test_that("T3.3 An error when the probabilities requested are above 1", {
+test_that("T3.3 An error when the probabilities requested are above 1", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_quantile(survfit_object,
+  expect_error(visR::get_quantile(survfit_object,
     probs = c(0.50, 1.00, 3.00)
   ))
 })
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T4. The function accepts a logical argument to request for the confidence intervals of the quantiles")
+context("get_pvalue - T4. The function accepts a logical argument to request for the confidence intervals of the quantiles")
 
-testthat::test_that("T4.1 No error when the argument to request confidence intervals is logical", {
+test_that("T4.1 No error when the argument to request confidence intervals is logical", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_quantile(survfit_object, conf.int = TRUE), NA)
+  expect_error(visR::get_quantile(survfit_object, conf.int = TRUE), NA)
 })
 
-testthat::test_that("T4.2 An error when the argument to request confidence intervals is not logical", {
+test_that("T4.2 An error when the argument to request confidence intervals is not logical", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_quantile(survfit_object, conf.int = "blah"))
+  expect_error(visR::get_quantile(survfit_object, conf.int = "blah"))
 })
 
-testthat::test_that("T4.3 An error when the confidence intervals are requested, but not estimated in the `survfit` object", {
+test_that("T4.3 An error when the confidence intervals are requested, but not estimated in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA", conf.int = FALSE)
-  testthat::expect_error(visR::get_quantile(survfit_object))
+  expect_error(visR::get_quantile(survfit_object))
 })
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T5. The function is a wrapper around quantile method for `survfit` objects")
+context("get_pvalue - T5. The function is a wrapper around quantile method for `survfit` objects")
 
-testthat::test_that("T5.1 The get_quantiles provides the same information as get_quantiles", {
+test_that("T5.1 The get_quantiles provides the same information as get_quantiles", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   quant_surv <- quantile(survfit_object)
 
@@ -129,46 +129,46 @@ testthat::test_that("T5.1 The get_quantiles provides the same information as get
 
   final <- final[order(final[, "strata"], final[, "quantity"]), ]
 
-  testthat::expect_equal(visR::get_quantile(survfit_object), final)
+  expect_equal(visR::get_quantile(survfit_object), final)
 })
 
 # Requirement T6 ---------------------------------------------------------------
 
-testthat::context("get_pvalue - T6. The function returns a dataframe with the requested information")
+context("get_pvalue - T6. The function returns a dataframe with the requested information")
 
-testthat::test_that("T6.1 The function returns a dataframe", {
+test_that("T6.1 The function returns a dataframe", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   quant <- visR::get_quantile(survfit_object, conf.int = TRUE)
 
-  testthat::expect_true(inherits(quant, "data.frame"))
+  expect_true(inherits(quant, "data.frame"))
 })
 
-testthat::test_that("T6.2 The output contains a column with the strata names", {
+test_that("T6.2 The output contains a column with the strata names", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   quant <- visR::get_quantile(survfit_object, conf.int = TRUE)
 
   stratNm <- unique(names(survfit_object[["strata"]]))
 
-  testthat::expect_equal(as.character(stratNm), as.character(unique(quant[["strata"]])))
+  expect_equal(as.character(stratNm), as.character(unique(quant[["strata"]])))
 })
 
-testthat::test_that("T6.3 The output contains a column with the quantities", {
+test_that("T6.3 The output contains a column with the quantities", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   quant <- visR::get_quantile(survfit_object, conf.int = TRUE)
 
   quaNm <- c("lower", "quantile", "upper")
 
-  testthat::expect_equal(as.character(quaNm), as.character(unique(quant[["quantity"]])))
+  expect_equal(as.character(quaNm), as.character(unique(quant[["quantity"]])))
 })
 
-testthat::test_that("T6.4 The output contains columns with the requested quantiles", {
+test_that("T6.4 The output contains columns with the requested quantiles", {
   probs <- c(0.50, 0.10)
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   quant <- visR::get_quantile(survfit_object, probs = probs)
 
   colNm <- colnames(quant)[-which(colnames(quant) %in% c("strata", "quantity"))]
 
-  testthat::expect_true(base::all(as.character(probs * 100) %in% colNm))
+  expect_true(base::all(as.character(probs * 100) %in% colNm))
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-get_risktable.R
+++ b/tests/testthat/test-get_risktable.R
@@ -57,165 +57,165 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("get_risktable.survfit - T1. The function accepts a `survfit` object")
+context("get_risktable.survfit - T1. The function accepts a `survfit` object")
 
-testthat::test_that("T1.1 No error when a `survfit` object is passed to the function", {
+test_that("T1.1 No error when a `survfit` object is passed to the function", {
   survfit_object <- survival::survfit(
     formula = survival::Surv(AVAL, 1 - CNSR) ~ TRTA,
     data = adtte
   )
 
-  testthat::expect_error(visR::get_risktable(survfit_object), NA)
+  expect_error(visR::get_risktable(survfit_object), NA)
 })
 
-testthat::test_that("T1.2 An error when a non-`survfit` object is passed to the function", {
+test_that("T1.2 An error when a non-`survfit` object is passed to the function", {
   survfit_object <- visR::estimate_KM(adtte, strata = "STUDYID")
   class(survfit_object) <- "blah"
-  testthat::expect_error(visR::get_risktable(survfit_object))
+  expect_error(visR::get_risktable(survfit_object))
 })
 
-testthat::test_that("T1.3 No error when no strata is present in the `survfit` object", {
+test_that("T1.3 No error when no strata is present in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte)
-  testthat::expect_error(visR::get_risktable(survfit_object), NA)
+  expect_error(visR::get_risktable(survfit_object), NA)
 })
 
-testthat::test_that("T1.4 No error when one strata is present in the `survfit` object", {
+test_that("T1.4 No error when one strata is present in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = c("SEX"))
-  testthat::expect_error(visR::get_risktable(survfit_object), NA)
+  expect_error(visR::get_risktable(survfit_object), NA)
 })
 
-testthat::test_that("T1.5 No error when multiple strata are present in the `survfit` object", {
+test_that("T1.5 No error when multiple strata are present in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = c("SEX", "TRTP"))
-  testthat::expect_error(visR::get_risktable(survfit_object), NA)
+  expect_error(visR::get_risktable(survfit_object), NA)
 })
 
-testthat::test_that("T1.6 The strata combinations are used, not the individual strata", {
+test_that("T1.6 The strata combinations are used, not the individual strata", {
   survfit_object <- visR::estimate_KM(adtte, strata = c("SEX", "TRTP"))
   risktable <- visR::get_risktable(survfit_object, group = "statlist")
-  testthat::expect_equal(
+  expect_equal(
     as.character(unique(risktable[["y_values"]])),
     visR:::.get_strata(names(survfit_object$strata))
   )
 })
 
-testthat::test_that("T1.7 When no strata were specified, an artificial strata is created 'Overall'", {
+test_that("T1.7 When no strata were specified, an artificial strata is created 'Overall'", {
   survfit_object <- visR::estimate_KM(adtte)
   risktable <- visR::get_risktable(survfit_object, group = "statlist")
   unique_yvals <- as.character(unique(risktable[["y_values"]]))
-  testthat::expect_equal(unique_yvals, "Overall")
+  expect_equal(unique_yvals, "Overall")
 })
 
 # Requirement T2 ----------------------------------------------------------
 
-testthat::context("get_risktable.survfit - T2. The function accepts an argument that specifies the time at which the risk set is calculated")
+context("get_risktable.survfit - T2. The function accepts an argument that specifies the time at which the risk set is calculated")
 
-testthat::test_that("T2.1 An error when the times specified are negative", {
+test_that("T2.1 An error when the times specified are negative", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object,
+  expect_error(visR::get_risktable(survfit_object,
     times = c(0, 5, -20, 9)
   ))
 })
 
-testthat::test_that("T2.2 The function orders the times argument internally to avoid errors", {
+test_that("T2.2 The function orders the times argument internally to avoid errors", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   times <- c(0, 9, 5, 10, 8, 3)
   risktable <- visR::get_risktable(survfit_object, times = times)
-  testthat::expect_equal(unique(risktable[["time"]]), times[order(times)])
+  expect_equal(unique(risktable[["time"]]), times[order(times)])
 })
 
-testthat::test_that("T2.3 The function proposes 11 times which are equally spaces when no times are specified", {
+test_that("T2.3 The function proposes 11 times which are equally spaces when no times are specified", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   risktable <- visR::get_risktable(survfit_object)
 
-  testthat::expect_equal(length(risktable[["time"]]), 11)
-  testthat::expect_equal(risktable[["time"]], seq(0, 200, 20))
+  expect_equal(length(risktable[["time"]]), 11)
+  expect_equal(risktable[["time"]], seq(0, 200, 20))
 })
 
-testthat::test_that("T2.4 The risktable is correctly calculated when only 1 timepoint is used", {
+test_that("T2.4 The risktable is correctly calculated when only 1 timepoint is used", {
   survfit_object <- visR::estimate_KM(adtte)
 
   risktable <- visR::get_risktable(survfit_object, times = 20, statlist = c("n.risk", "n.event", "n.censor", "cum.event", "cum.censor"))
 
   expect <- c(summary(survfit_object, times = 20)[["n.risk"]], summary(survfit_object, times = 20)[["n.event"]], summary(survfit_object, times = 20)[["n.censor"]], summary(survfit_object, times = 20)[["n.event"]], summary(survfit_object, times = 20)[["n.censor"]])
 
-  testthat::expect_equal(risktable[["Overall"]], expect)
+  expect_equal(risktable[["Overall"]], expect)
 })
 
 # Requirement T3 ----------------------------------------------------------
 
-testthat::context("get_risktable.survfit - T3. The function accepts a `statlist` to be displayed for which labels can be specified")
+context("get_risktable.survfit - T3. The function accepts a `statlist` to be displayed for which labels can be specified")
 
-testthat::test_that("T3.1 No error when the `statlist` contains allowed strings", {
+test_that("T3.1 No error when the `statlist` contains allowed strings", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object, statlist = "n.risk"), NA)
+  expect_error(visR::get_risktable(survfit_object, statlist = "n.risk"), NA)
 })
 
-testthat::test_that("T3.2 An error when the `statlist` contains non-allowed strings eg 'blah'", {
+test_that("T3.2 An error when the `statlist` contains non-allowed strings eg 'blah'", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object,
+  expect_error(visR::get_risktable(survfit_object,
     statlist = c("blah", "n.risk", -3)
   ))
 })
 
-testthat::test_that("T3.3 Duplicate entries are removed from `statlist`", {
+test_that("T3.3 Duplicate entries are removed from `statlist`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   risktable <- visR::get_risktable(survfit_object,
     statlist = c("n.risk", "n.risk")
   )
   n_levels <- length(risktable[which(risktable[["time"]] == 0), "y_values"])
 
-  testthat::expect_equal(n_levels, 1)
+  expect_equal(n_levels, 1)
 })
 
-testthat::test_that("T3.4 An error when the `label` is not a character vector or a factor", {
+test_that("T3.4 An error when the `label` is not a character vector or a factor", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object, label = 10))
+  expect_error(visR::get_risktable(survfit_object, label = 10))
 })
 
-testthat::test_that("T3.5 No error when the `label` is a character vector", {
+test_that("T3.5 No error when the `label` is a character vector", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   label <- c("blah", "moreblah")
-  testthat::expect_error(visR::get_risktable(survfit_object, label = label), NA)
+  expect_error(visR::get_risktable(survfit_object, label = label), NA)
 })
 
-testthat::test_that("T3.6 No error when the `label` is a factor", {
+test_that("T3.6 No error when the `label` is a factor", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   label <- as.factor(c("blah", "moreblah"))
-  testthat::expect_error(visR::get_risktable(survfit_object, label = label), NA)
+  expect_error(visR::get_risktable(survfit_object, label = label), NA)
 })
 
 # Requirement T4 ----------------------------------------------------------
 
-testthat::context("get_risktable.survfit - T4. The function matches the length of the `label` vector with that of the `statlist` vector")
+context("get_risktable.survfit - T4. The function matches the length of the `label` vector with that of the `statlist` vector")
 
-testthat::test_that("T4.1 The function supplies defaults to increase the length of the `label` vector to same length as the `statlist` vector", {
+test_that("T4.1 The function supplies defaults to increase the length of the `label` vector to same length as the `statlist` vector", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   risktable <- visR::get_risktable(survfit_object,
     label = c("label 1"),
     statlist = c("n.risk", "n.censor")
   )
-  testthat::expect_equal(nrow(unique(risktable["y_values"])), 2)
+  expect_equal(nrow(unique(risktable["y_values"])), 2)
 })
 
-testthat::test_that("T4.2 The supplied defaults for the `label` vector match the arguments specified in the `statlist`", {
+test_that("T4.2 The supplied defaults for the `label` vector match the arguments specified in the `statlist`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   risktable <- visR::get_risktable(survfit_object,
     statlist = c("n.risk", "n.censor")
   )
-  testthat::expect_equal(
+  expect_equal(
     as.character(unique(unlist(risktable["y_values"]))),
     c("At risk", "Censored")
   )
 })
 
-testthat::test_that("T4.3 The function limits the length of the `label` vector to the length of the `statlist` vector", {
+test_that("T4.3 The function limits the length of the `label` vector to the length of the `statlist` vector", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   risktable <- visR::get_risktable(survfit_object,
     label = paste("label", seq(1, 4)),
     statlist = c("n.risk", "n.censor")
   )
-  testthat::expect_equal(nrow(unique(risktable["y_values"])), 2)
-  testthat::expect_equal(
+  expect_equal(nrow(unique(risktable["y_values"])), 2)
+  expect_equal(
     as.character(unique(unlist(risktable["y_values"]))),
     c("label 1", "label 2")
   )
@@ -223,9 +223,9 @@ testthat::test_that("T4.3 The function limits the length of the `label` vector t
 
 # Requirement T5 ----------------------------------------------------------
 
-testthat::context("get_risktable.survfit - T5. T5. The functions calculates requested summary across time")
+context("get_risktable.survfit - T5. T5. The functions calculates requested summary across time")
 
-testthat::test_that("T5.1 The function is able to calculate the number of events from a `survfit` object", {
+test_that("T5.1 The function is able to calculate the number of events from a `survfit` object", {
   survobj <- survival::survfit.formula(data = adtte, formula = survival::Surv(AVAL, 1 - CNSR) ~ 1)
   atrisk <- summary(survobj, times = c(0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200), extend = TRUE)[["n.risk"]]
 
@@ -233,10 +233,10 @@ testthat::test_that("T5.1 The function is able to calculate the number of events
     visR::get_risktable(group = "statlist") %>%
     dplyr::pull(n.risk)
 
-  testthat::expect_equal(atrisk, atrisk_visr)
+  expect_equal(atrisk, atrisk_visr)
 })
 
-testthat::test_that("T5.2 The function is able to calculate the number of censored events from a `survfit` object", {
+test_that("T5.2 The function is able to calculate the number of censored events from a `survfit` object", {
   survobj <- survival::survfit.formula(data = adtte, formula = survival::Surv(AVAL, CNSR) ~ 1)
   censored <- summary(survobj, times = c(0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200), extend = TRUE)[["n.event"]]
 
@@ -244,10 +244,10 @@ testthat::test_that("T5.2 The function is able to calculate the number of censor
     visR::get_risktable(group = "statlist", statlist = "n.censor") %>%
     dplyr::pull(n.censor)
 
-  testthat::expect_equal(censored, censor_visr)
+  expect_equal(censored, censor_visr)
 })
 
-testthat::test_that("T5.3 The function is able to calculate the number of at risk from a `survfit` object", {
+test_that("T5.3 The function is able to calculate the number of at risk from a `survfit` object", {
   survobj <- survival::survfit.formula(data = adtte, formula = survival::Surv(AVAL, 1 - CNSR) ~ 1)
   events <- summary(survobj, times = c(0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200), extend = TRUE)[["n.event"]]
 
@@ -255,10 +255,10 @@ testthat::test_that("T5.3 The function is able to calculate the number of at ris
     visR::get_risktable(group = "statlist", statlist = "n.event") %>%
     dplyr::pull(n.event)
 
-  testthat::expect_equal(events, events_visr)
+  expect_equal(events, events_visr)
 })
 
-testthat::test_that("T5.4 The function is able to calculate the cumulative number of censored events from a `survfit` object", {
+test_that("T5.4 The function is able to calculate the cumulative number of censored events from a `survfit` object", {
   survobj <- survival::survfit.formula(data = adtte, formula = survival::Surv(AVAL, CNSR) ~ 1)
   censored <- summary(survobj, times = c(0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200), extend = TRUE)[["n.event"]]
   cum.censor <- cumsum(censored)
@@ -267,10 +267,10 @@ testthat::test_that("T5.4 The function is able to calculate the cumulative numbe
     visR::get_risktable(group = "statlist", statlist = "cum.censor") %>%
     dplyr::pull(cum.censor)
 
-  testthat::expect_equal(cum.censor, cumcensor_visr)
+  expect_equal(cum.censor, cumcensor_visr)
 })
 
-testthat::test_that("T5.5 The function is able to calculate the cumulative number of events from a `survfit` object", {
+test_that("T5.5 The function is able to calculate the cumulative number of events from a `survfit` object", {
   survobj <- survival::survfit.formula(data = adtte, formula = survival::Surv(AVAL, 1 - CNSR) ~ 1)
   events <- summary(survobj, times = c(0, 20, 40, 60, 80, 100, 120, 140, 160, 180, 200), extend = TRUE)[["n.event"]]
   cum.events <- cumsum(events)
@@ -279,36 +279,36 @@ testthat::test_that("T5.5 The function is able to calculate the cumulative numbe
     visR::get_risktable(group = "statlist", statlist = "cum.event") %>%
     dplyr::pull(cum.event)
 
-  testthat::expect_equal(cum.events, cumevents_visr)
+  expect_equal(cum.events, cumevents_visr)
 })
 
 # Requirement T6 ---------------------------------------------------------------
 
-testthat::context("get_risktable.survfit - T6. The function groups the calculation by strata, by statlist or overall")
+context("get_risktable.survfit - T6. The function groups the calculation by strata, by statlist or overall")
 
-testthat::test_that("T6.1 An error when the `group` argument is not equal to `strata` or `statlist`", {
+test_that("T6.1 An error when the `group` argument is not equal to `strata` or `statlist`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object, group = "blah"))
+  expect_error(visR::get_risktable(survfit_object, group = "blah"))
 })
 
-testthat::test_that("T6.2 An error when the `group` argument is not of length 1", {
+test_that("T6.2 An error when the `group` argument is not of length 1", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object,
+  expect_error(visR::get_risktable(survfit_object,
     group = c("statlist", "strata")
   ))
 })
 
-testthat::test_that("T6.3 No error when the `group` argument is `strata`", {
+test_that("T6.3 No error when the `group` argument is `strata`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object, group = "strata"), NA)
+  expect_error(visR::get_risktable(survfit_object, group = "strata"), NA)
 })
 
-testthat::test_that("T6.4 No error when the `group` arguments is `statlist`", {
+test_that("T6.4 No error when the `group` arguments is `statlist`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object, group = "statlist"), NA)
+  expect_error(visR::get_risktable(survfit_object, group = "statlist"), NA)
 })
 
-testthat::test_that("T6.5 The calculations are grouped by strata when group = `strata`", {
+test_that("T6.5 The calculations are grouped by strata when group = `strata`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   risktable <- visR::get_risktable(
 
@@ -316,13 +316,13 @@ testthat::test_that("T6.5 The calculations are grouped by strata when group = `s
     group = "strata",
     statlist = c("n.risk", "n.censor", "n.event")
   )
-  testthat::expect_equal(
+  expect_equal(
     object = colnames(risktable[3:length(colnames(risktable))]),
     expected = gsub("^.*=", "", names(survfit_object$strata))
   )
 })
 
-testthat::test_that("T6.6 The calculations are grouped by statlist when group = `statlist`", {
+test_that("T6.6 The calculations are grouped by statlist when group = `statlist`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
 
   risktable <- visR::get_risktable(
@@ -331,17 +331,17 @@ testthat::test_that("T6.6 The calculations are grouped by statlist when group = 
     statlist = c("n.risk", "n.censor", "n.event", "cum.censor", "cum.event")
   )
 
-  testthat::expect_equal(
+  expect_equal(
     object = levels(risktable[["y_values"]]),
     expected = gsub("^.*=", "", names(survfit_object$strata))
   )
-  testthat::expect_equal(
+  expect_equal(
     object = colnames(risktable[3:length(colnames(risktable))]),
     expected = c("n.risk", "n.censor", "n.event", "cum.censor", "cum.event")
   )
 })
 
-testthat::test_that("T6.7 The calculations are in agreement with what is expected", {
+test_that("T6.7 The calculations are in agreement with what is expected", {
 
   ## test for strata
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
@@ -365,7 +365,7 @@ testthat::test_that("T6.7 The calculations are in agreement with what is expecte
 
   class(risktable_ref) <- c("risktable", class(risktable_ref))
 
-  testthat::expect_equal(risktable_visR, risktable_ref)
+  expect_equal(risktable_visR, risktable_ref)
 
   ## test for statlist
   survfit_object <- visR::estimate_KM(adtte)
@@ -387,36 +387,36 @@ testthat::test_that("T6.7 The calculations are in agreement with what is expecte
     class = c("risktable", "data.frame")
   )
 
-  testthat::expect_equal(risktable_visR, risktable_ref)
+  expect_equal(risktable_visR, risktable_ref)
 
   attributes(risktable_ref)
 })
 
 # Requirement T7 ---------------------------------------------------------------
 
-testthat::context("get_risktable.survfit - T7. The function allows the calculations to be grouped overall ")
+context("get_risktable.survfit - T7. The function allows the calculations to be grouped overall ")
 
-testthat::test_that("T7.1 An error when the argument collapse is not boolean", {
+test_that("T7.1 An error when the argument collapse is not boolean", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object, collapse = "blah"))
+  expect_error(visR::get_risktable(survfit_object, collapse = "blah"))
 })
 
-testthat::test_that("T7.2 No error when the argument collapse is boolean", {
+test_that("T7.2 No error when the argument collapse is boolean", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_error(visR::get_risktable(survfit_object, collapse = TRUE), NA)
+  expect_error(visR::get_risktable(survfit_object, collapse = TRUE), NA)
 })
 
-testthat::test_that("T7.3 The calculations are grouped overall when collapse = TRUE", {
+test_that("T7.3 The calculations are grouped overall when collapse = TRUE", {
   survfit_object_trt <- visR::estimate_KM(adtte, strata = "TRTA")
   survfit_object_all <- visR::estimate_KM(adtte)
 
   risktable_visR_trt <- visR::get_risktable(survfit_object_trt, group = "strata", collapse = TRUE)
   risktable_visR_all <- visR::get_risktable(survfit_object_all, group = "strata")
 
-  testthat::expect_equal(risktable_visR_trt, risktable_visR_all)
+  expect_equal(risktable_visR_trt, risktable_visR_all)
 })
 
-testthat::test_that("T7.4 The calculations are in agreement with expectations when grouped overall", {
+test_that("T7.4 The calculations are in agreement with expectations when grouped overall", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   risktable_ungroup <- visR::get_risktable(survfit_object, collapse = FALSE)
   risktable_group <- visR::get_risktable(survfit_object, collapse = TRUE)
@@ -428,52 +428,52 @@ testthat::test_that("T7.4 The calculations are in agreement with expectations wh
   attributes(risktable_group) <- NULL
   attributes(risktable_test) <- NULL
 
-  testthat::expect_equal(risktable_test, risktable_group)
+  expect_equal(risktable_test, risktable_group)
 })
 
-testthat::test_that("T7.5 No error when there is only one strata available and collapse = TRUE", {
+test_that("T7.5 No error when there is only one strata available and collapse = TRUE", {
   survfit_object <- visR::estimate_KM(adtte)
   risktable_visR <- visR::get_risktable(survfit_object, collapse = TRUE)
-  testthat::expect_error(visR::get_risktable(survfit_object, collapse = TRUE), NA)
+  expect_error(visR::get_risktable(survfit_object, collapse = TRUE), NA)
 })
 
 # Requirement T8 ----------------------------------------------------------
 
-testthat::context("get_risktable.survfit - T8. The output dataset is a data.frame with attributes for downstream processing")
+context("get_risktable.survfit - T8. The output dataset is a data.frame with attributes for downstream processing")
 
-testthat::test_that("T8.1 The output dataset is a data.frame", {
+test_that("T8.1 The output dataset is a data.frame", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
-  testthat::expect_true(inherits(visR::get_risktable(survfit_object), "data.frame"))
+  expect_true(inherits(visR::get_risktable(survfit_object), "data.frame"))
 })
 
-testthat::test_that("T8.2 The output dataset has the attribute `time_ticks` that specifies the times", {
+test_that("T8.2 The output dataset has the attribute `time_ticks` that specifies the times", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
   times <- c(20, 40, 80)
   risktable <- visR::get_risktable(survfit_object, times = times)
-  testthat::expect_equal(attr(risktable, "time_ticks"), times)
+  expect_equal(attr(risktable, "time_ticks"), times)
 })
 
-testthat::test_that("T8.3 The output dataset has the attribute `title` that specifies the labels used in downstream functions", {
+test_that("T8.3 The output dataset has the attribute `title` that specifies the labels used in downstream functions", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
 
   risktable_bystat <- visR::get_risktable(survfit_object, group = "statlist")
   risktable_bystrat <- visR::get_risktable(survfit_object, group = "strata")
 
-  testthat::expect_equal(attr(risktable_bystat, "title"), "At risk")
-  testthat::expect_equal(
+  expect_equal(attr(risktable_bystat, "title"), "At risk")
+  expect_equal(
     attr(risktable_bystrat, "title"),
     sub(".*=", "", names(survfit_object$strata))
   )
 })
 
-testthat::test_that("T8.4 The output dataset has the attribute `statlist` that reflects the ´group´ used", {
+test_that("T8.4 The output dataset has the attribute `statlist` that reflects the ´group´ used", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTA")
 
   risktable_bystat <- visR::get_risktable(survfit_object, group = "statlist")
   risktable_bystrat <- visR::get_risktable(survfit_object, group = "strata")
 
-  testthat::expect_equal(attr(risktable_bystat, "statlist"), "n.risk")
-  testthat::expect_equal(
+  expect_equal(attr(risktable_bystat, "statlist"), "n.risk")
+  expect_equal(
     attr(risktable_bystrat, "statlist"),
     sub(".*=", "", names(survfit_object$strata))
   )
@@ -481,9 +481,9 @@ testthat::test_that("T8.4 The output dataset has the attribute `statlist` that r
 
 # Requirement T9 ----------------------------------------------------------
 
-testthat::context("get_risktable.survfit - T9. Tests for `get_risktable.tidycmprsk()`")
+context("get_risktable.survfit - T9. Tests for `get_risktable.tidycmprsk()`")
 
-testthat::test_that("T9.1 Results are accurate without error", {
+test_that("T9.1 Results are accurate without error", {
   cuminc <-
     visR::estimate_cuminc(
       tidycmprsk::trial,
@@ -491,7 +491,7 @@ testthat::test_that("T9.1 Results are accurate without error", {
       CNSR = "death_cr"
     )
 
-  testthat::expect_equal(
+  expect_equal(
     cuminc %>%
       get_risktable(times = 12, statlist = c("n.event", "n.risk", "n.censor")),
     cuminc %>%
@@ -520,7 +520,7 @@ testthat::test_that("T9.1 Results are accurate without error", {
       strata = "trt"
     )
 
-  testthat::expect_equal(
+  expect_equal(
     cuminc2 %>%
       get_risktable(
         times = 12,
@@ -545,7 +545,7 @@ testthat::test_that("T9.1 Results are accurate without error", {
     check.attributes = FALSE
   )
 
-  testthat::expect_equal(
+  expect_equal(
     cuminc2 %>%
       get_risktable(
         times = 12,
@@ -573,7 +573,7 @@ testthat::test_that("T9.1 Results are accurate without error", {
     check.attributes = FALSE
   )
 
-  testthat::expect_equal(
+  expect_equal(
     cuminc2 %>%
       get_risktable(
         times = 12,

--- a/tests/testthat/test-get_summary.R
+++ b/tests/testthat/test-get_summary.R
@@ -27,86 +27,86 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("get_summary - T1. The function accepts a survival object")
+context("get_summary - T1. The function accepts a survival object")
 
-testthat::test_that("T1.1 No error when `survfit_object` is a survfit object", {
+test_that("T1.1 No error when `survfit_object` is a survfit object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
-  testthat::expect_error(visR::get_summary(survfit_object), NA)
+  expect_error(visR::get_summary(survfit_object), NA)
 })
 
-testthat::test_that("T1.2 An error when `survfit_object` is a data.frame", {
+test_that("T1.2 An error when `survfit_object` is a data.frame", {
   survfit_object <- visR::adtte
-  testthat::expect_error(visR::get_summary(survfit_object))
+  expect_error(visR::get_summary(survfit_object))
 })
 
-testthat::test_that("T1.3 An error when `survfit_object` is a tibble", {
+test_that("T1.3 An error when `survfit_object` is a tibble", {
   survfit_object <- tibble::as_tibble(visR::adtte)
-  testthat::expect_error(visR::get_summary(survfit_object))
+  expect_error(visR::get_summary(survfit_object))
 })
 
-testthat::test_that("T1.4 An error when `survfit_object` is a data.table", {
+test_that("T1.4 An error when `survfit_object` is a data.table", {
   survfit_object <- data.table::as.data.table(visR::adtte)
-  testthat::expect_error(visR::get_summary(survfit_object))
+  expect_error(visR::get_summary(survfit_object))
 })
 
-testthat::test_that("T1.5 An error when `survfit_object` is a random object", {
+test_that("T1.5 An error when `survfit_object` is a random object", {
   survfit_object <- "A"
-  testthat::expect_error(visR::get_summary(survfit_object))
+  expect_error(visR::get_summary(survfit_object))
 })
 
-testthat::test_that("T1.6 An error when `survfit_object` is NULL", {
+test_that("T1.6 An error when `survfit_object` is NULL", {
   survfit_object <- NULL
-  testthat::expect_error(visR::get_summary(survfit_object))
+  expect_error(visR::get_summary(survfit_object))
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("get_summary - T2. The function accepts an argument that specifies the summaries to be displayed")
+context("get_summary - T2. The function accepts an argument that specifies the summaries to be displayed")
 
-testthat::test_that("T2.1 An error when `statlist` is NULL", {
+test_that("T2.1 An error when `statlist` is NULL", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
 
-  testthat::expect_error(visR::get_summary(survfit_object, statlist = NULL))
+  expect_error(visR::get_summary(survfit_object, statlist = NULL))
 })
 
-testthat::test_that("T2.2 An error when the `statlist` contains non-allowed strings e.g. `blah`", {
+test_that("T2.2 An error when the `statlist` contains non-allowed strings e.g. `blah`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
   statlist <- c("strata", "blah")
 
-  testthat::expect_error(visR::get_summary(survfit_object, statlist = statlist))
+  expect_error(visR::get_summary(survfit_object, statlist = statlist))
 })
 
-testthat::test_that("T2.3 No error when the `statlist` contains arguments `strata`, `records`, `events`, `median`, `LCL`, `UCL`, or `CI`", {
+test_that("T2.3 No error when the `statlist` contains arguments `strata`, `records`, `events`, `median`, `LCL`, `UCL`, or `CI`", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
   statlist <- c("strata", "records", "events", "median", "LCL", "UCL", "CI")
 
-  testthat::expect_error(visR::get_summary(survfit_object, statlist = statlist), NA)
+  expect_error(visR::get_summary(survfit_object, statlist = statlist), NA)
 })
 
-testthat::test_that("T2.4 The values in the column `strata` are the same as the `strata` in the `survfit` object", {
+test_that("T2.4 The values in the column `strata` are the same as the `strata` in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
   strata <- unlist(visR::get_summary(survfit_object, statlist = c("strata")))
 
-  testthat::expect_equal(names(survfit_object$strata), unname(strata))
+  expect_equal(names(survfit_object$strata), unname(strata))
 })
 
-testthat::test_that("T2.5. The values in the column `strata` contain 'Overall' when no strata are present in the `survfit` object", {
+test_that("T2.5. The values in the column `strata` contain 'Overall' when no strata are present in the `survfit` object", {
   survfit_object <- survival::survfit(survival::Surv(AVAL, 1 - CNSR) ~ 1,
     data = adtte
   )
   strata <- unlist(visR::get_summary(survfit_object, statlist = c("strata")))
 
-  testthat::expect_equal("Overall", unname(strata))
+  expect_equal("Overall", unname(strata))
 })
 
-testthat::test_that("T2.6 The values in the column `No. of subjects` are the same as the values of `n` in the `survfit` object", {
+test_that("T2.6 The values in the column `No. of subjects` are the same as the values of `n` in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte)
   strata <- unlist(visR::get_summary(survfit_object, statlist = "records"))
 
-  testthat::expect_equal(survfit_object$n, unname(strata))
+  expect_equal(survfit_object$n, unname(strata))
 })
 
-testthat::test_that("T2.7 The values in the column `No. of events` are the same as the events in the `survfit` object", {
+test_that("T2.7 The values in the column `No. of events` are the same as the events in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
   df <- data.frame(
     `n.events` = survfit_object$n.event,
@@ -115,10 +115,10 @@ testthat::test_that("T2.7 The values in the column `No. of events` are the same 
   aggregated_events <- stats::aggregate(n.events ~ strata, data = df, sum)$n.events
   strata <- unlist(visR::get_summary(survfit_object, statlist = c("events")))
 
-  testthat::expect_equal(aggregated_events, unname(strata))
+  expect_equal(aggregated_events, unname(strata))
 })
 
-testthat::test_that("T2.8 The values in the column `Median(surv.time)` are the same as the median values in the `survfit` object", {
+test_that("T2.8 The values in the column `Median(surv.time)` are the same as the median values in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
 
   df <- data.frame(
@@ -139,10 +139,10 @@ testthat::test_that("T2.8 The values in the column `Median(surv.time)` are the s
     df[df$strata == as.character(ind[1]), ][as.numeric(ind[2]), "time"]
   })
 
-  testthat::expect_equal(medians, unname(strata))
+  expect_equal(medians, unname(strata))
 })
 
-testthat::test_that("T2.9 The values in the column `0.95LCL` are the same as the lower confidence values in the `survfit` object", {
+test_that("T2.9 The values in the column `0.95LCL` are the same as the lower confidence values in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
 
   df <- data.frame(
@@ -163,10 +163,10 @@ testthat::test_that("T2.9 The values in the column `0.95LCL` are the same as the
 
   strata <- unlist(visR::get_summary(survfit_object, statlist = c("LCL")))
 
-  testthat::expect_equal(lower, unname(strata))
+  expect_equal(lower, unname(strata))
 })
 
-testthat::test_that("T2.10 The values in the column `0.95UCL` are the same as the upper confidence values in the `survfit` object", {
+test_that("T2.10 The values in the column `0.95UCL` are the same as the upper confidence values in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
 
   df <- data.frame(
@@ -187,10 +187,10 @@ testthat::test_that("T2.10 The values in the column `0.95UCL` are the same as th
 
   strata <- unlist(visR::get_summary(survfit_object, statlist = c("UCL")))
 
-  testthat::expect_equal(upper, unname(strata))
+  expect_equal(upper, unname(strata))
 })
 
-testthat::test_that("T2.11 The values in the column `0.95CI` are the same as the confidence intervals in the `survfit` object", {
+test_that("T2.11 The values in the column `0.95CI` are the same as the confidence intervals in the `survfit` object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP")
 
   df <- data.frame(
@@ -224,20 +224,20 @@ testthat::test_that("T2.11 The values in the column `0.95CI` are the same as the
 
   strata <- unlist(visR::get_summary(survfit_object, statlist = c("CI")))
 
-  testthat::expect_equal(ci, unname(strata))
+  expect_equal(ci, unname(strata))
 })
 
-testthat::test_that("T2.12 An error when the confidence intervals are requested and not calculated in the survival object", {
+test_that("T2.12 An error when the confidence intervals are requested and not calculated in the survival object", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP", conf.type = "none")
   suppressWarnings(
-    testthat::expect_error(visR::get_summary(survfit_object, statlist = c("CI")))
+    expect_error(visR::get_summary(survfit_object, statlist = c("CI")))
   )
 })
 
-testthat::test_that("T2.13 Column name for confidence intervals changes for different confidence levels", {
+test_that("T2.13 Column name for confidence intervals changes for different confidence levels", {
   survfit_object <- visR::estimate_KM(adtte, strata = "TRTP", conf.int = 0.80)
   ci_colnames <- colnames(visR::get_summary(survfit_object, statlist = c("CI")))
-  testthat::expect_equal("0.8CI", ci_colnames)
+  expect_equal("0.8CI", ci_colnames)
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-get_tableone.R
+++ b/tests/testthat/test-get_tableone.R
@@ -30,56 +30,56 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("get_tableone - T1. The function accepts a `data.frame` `tibble` or `data.table`")
+context("get_tableone - T1. The function accepts a `data.frame` `tibble` or `data.table`")
 
-testthat::test_that("T1.1. No error when `data` is of class `data.frame`", {
-  testthat::expect_error(visR::get_tableone(data = adtte), NA)
+test_that("T1.1. No error when `data` is of class `data.frame`", {
+  expect_error(visR::get_tableone(data = adtte), NA)
 })
 
 
-testthat::test_that("T1.2. No error when `data` is of class `tibble`", {
+test_that("T1.2. No error when `data` is of class `tibble`", {
   data <- dplyr::as_tibble(adtte)
 
-  testthat::expect_error(visR::get_tableone(data = data), NA)
+  expect_error(visR::get_tableone(data = data), NA)
 })
 
-testthat::test_that("T1.3 No error when `data` is of class `data.table`", {
+test_that("T1.3 No error when `data` is of class `data.table`", {
   if (nzchar(find.package("data.table"))) {
     data <- data.table::as.data.table(adtte)
-    testthat::expect_error(visR::get_tableone(data = data), NA)
+    expect_error(visR::get_tableone(data = data), NA)
   }
 })
 
-testthat::test_that("T1.4 An error when `data` is of class `list`", {
+test_that("T1.4 An error when `data` is of class `list`", {
   data <- base::as.list(adtte)
-  testthat::expect_error(visR::get_tableone(data = data))
+  expect_error(visR::get_tableone(data = data))
 })
 
-testthat::test_that("T1.5 An error when `data` is NULL", {
-  testthat::expect_error(visR::get_tableone(data = NULL))
+test_that("T1.5 An error when `data` is NULL", {
+  expect_error(visR::get_tableone(data = NULL))
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("get_tableone - T2. The function accepts a list of `colnames` in the `data` as `strata`")
+context("get_tableone - T2. The function accepts a list of `colnames` in the `data` as `strata`")
 
-testthat::test_that("T2.1 An error when `strata` is a number", {
-  testthat::expect_error(visR::get_tableone(data = adtte, strata = 1))
+test_that("T2.1 An error when `strata` is a number", {
+  expect_error(visR::get_tableone(data = adtte, strata = 1))
 })
 
-testthat::test_that("T2.2 An error when `strata` is a string that is not a colname in `data`", {
-  testthat::expect_error(visR::get_tableone(data = adtte, strata = "blah"))
+test_that("T2.2 An error when `strata` is a string that is not a colname in `data`", {
+  expect_error(visR::get_tableone(data = adtte, strata = "blah"))
 })
 
-testthat::test_that("T2.3 Additional colnames in the tableone are the `strata` values (for one `strata`)", {
+test_that("T2.3 Additional colnames in the tableone are the `strata` values (for one `strata`)", {
   trtp_colnames <- colnames(visR::get_tableone(
     data = adtte,
     strata = c("TRTP")
   ))[4:6]
-  testthat::expect_equal(trtp_colnames, levels(adtte$TRTP))
+  expect_equal(trtp_colnames, levels(adtte$TRTP))
 })
 
-testthat::test_that("T2.4 Additional colnames in the tableone are the crossproduct of all `strata` values (for more than one `strata`)", {
+test_that("T2.4 Additional colnames in the tableone are the crossproduct of all `strata` values (for more than one `strata`)", {
   mapply_colnames <- c(mapply(function(x, y) paste(x, y, sep = "_"),
     levels(adtte$TRTP),
     MoreArgs = list(levels(adtte$SEX))
@@ -88,33 +88,33 @@ testthat::test_that("T2.4 Additional colnames in the tableone are the crossprodu
     data = adtte,
     strata = c("TRTP", "SEX")
   ))[4:9]
-  testthat::expect_equal(mapply_colnames, visR_colnames)
+  expect_equal(mapply_colnames, visR_colnames)
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("get_tableone - T3. The tableone includes expected columnnames")
+context("get_tableone - T3. The tableone includes expected columnnames")
 
-testthat::test_that("T3.1 Tableone by default includes columns `variable`, `statistic`, and `Total`", {
+test_that("T3.1 Tableone by default includes columns `variable`, `statistic`, and `Total`", {
   tableone_colnames <- colnames(visR::get_tableone(data = adtte))
 
-  testthat::expect_equal(tableone_colnames, c("variable", "statistic", "Total"))
+  expect_equal(tableone_colnames, c("variable", "statistic", "Total"))
 })
 
-testthat::test_that("T3.2 Tableone still includes the colum `Total` if `overall` is FALSE but no `strata` is given", {
+test_that("T3.2 Tableone still includes the colum `Total` if `overall` is FALSE but no `strata` is given", {
   tableone_colnames <- colnames(visR::get_tableone(data = adtte, overall = FALSE))
 
-  testthat::expect_equal(tableone_colnames, c("variable", "statistic", "Total"))
+  expect_equal(tableone_colnames, c("variable", "statistic", "Total"))
 })
 
-testthat::test_that("T3.3 Tableone does not include the colum `Total` if `overall` is FALSE and a `strata` is given", {
+test_that("T3.3 Tableone does not include the colum `Total` if `overall` is FALSE and a `strata` is given", {
   tblone_colnames <- colnames(visR::get_tableone(
     data = adtte,
     overall = FALSE,
     strata = c("TRTP")
   ))
 
-  testthat::expect_equal(
+  expect_equal(
     tblone_colnames,
     c("variable", "statistic", levels(adtte$TRTP))
   )
@@ -122,39 +122,39 @@ testthat::test_that("T3.3 Tableone does not include the colum `Total` if `overal
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("get_tableone - T4. The function only accepts suitable summary functions")
+context("get_tableone - T4. The function only accepts suitable summary functions")
 
-testthat::test_that("T4.1 An error when the `summary_function` is NULL", {
-  testthat::expect_error(visR::get_tableone(
+test_that("T4.1 An error when the `summary_function` is NULL", {
+  expect_error(visR::get_tableone(
     data = adtte,
     summary_function = NULL
   ))
 })
 
-testthat::test_that("T4.2 An error when the `summary_function` is a string", {
-  testthat::expect_error(visR::get_tableone(
+test_that("T4.2 An error when the `summary_function` is a string", {
+  expect_error(visR::get_tableone(
     data = adtte,
     summary_function = "A"
   ))
 })
 
-testthat::test_that("T4.3 An error when the `summary_function` is a function not build for it", {
-  testthat::expect_error(visR::get_tableone(
+test_that("T4.3 An error when the `summary_function` is a function not build for it", {
+  expect_error(visR::get_tableone(
     data = adtte,
     summary_function = sum
   ))
 })
 
-testthat::test_that("T4.4 An error when the `summary_function` is `summarize_long`", {
-  testthat::expect_error(visR::get_tableone(
+test_that("T4.4 An error when the `summary_function` is `summarize_long`", {
+  expect_error(visR::get_tableone(
     data = adtte,
     summary_function = summarize_long
   ))
 })
 
 
-testthat::test_that("T4.5 No error when the `summary_function` is `summarize_short`", {
-  testthat::expect_error(visR::get_tableone(
+test_that("T4.5 No error when the `summary_function` is `summarize_short`", {
+  expect_error(visR::get_tableone(
     data = adtte,
     summary_function = summarize_short
   ), NA)
@@ -162,29 +162,29 @@ testthat::test_that("T4.5 No error when the `summary_function` is `summarize_sho
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("get_tableone - T5. The tableone removes strata variables in rows that leads NA values")
+context("get_tableone - T5. The tableone removes strata variables in rows that leads NA values")
 
-testthat::test_that("T5.1 An error when the the table includes one strata variable", {
+test_that("T5.1 An error when the the table includes one strata variable", {
   strata <- c("SEX")
 
   table <- adtte %>%
     visR::get_tableone(strata = strata)
 
-  testthat::expect_true(sum(strata %in% unique(table$variable)) == 0)
+  expect_true(sum(strata %in% unique(table$variable)) == 0)
 })
 
-testthat::test_that("T5.2 An error when the the table includes multiple strata variables", {
+test_that("T5.2 An error when the the table includes multiple strata variables", {
   strata <- c("SEX", "RACE")
 
   table <- adtte %>%
     visR::get_tableone(strata = strata)
 
-  testthat::expect_true(sum(strata %in% unique(table$variable)) == 0)
+  expect_true(sum(strata %in% unique(table$variable)) == 0)
 
   table <- adtte %>%
     visR::get_tableone(strata = strata, overall = FALSE)
 
-  testthat::expect_true(sum(strata %in% unique(table$variable)) == 0)
+  expect_true(sum(strata %in% unique(table$variable)) == 0)
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-render.R
+++ b/tests/testthat/test-render.R
@@ -514,7 +514,7 @@ testthat::test_that("T2.7 No error when `footnote` is defined.", {
       datasource = NULL,
       footnote = 1
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -522,7 +522,7 @@ testthat::test_that("T2.7 No error when `footnote` is defined.", {
       datasource = NULL,
       footnote = "visR"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -530,10 +530,10 @@ testthat::test_that("T2.7 No error when `footnote` is defined.", {
       datasource = NULL,
       footnote = c(1, 2, 3)
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.8 No error when `output_format` is 'html' and `engine` is 'gt'.", {
+test_that("T2.8 No error when `output_format` is 'html' and `engine` is 'gt'.", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -545,10 +545,10 @@ testthat::test_that("T2.8 No error when `output_format` is 'html' and `engine` i
       output_format = "html",
       engine = "gt"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.9 No error when `output_format` is 'html' and `engine` is 'kable'.", {
+test_that("T2.9 No error when `output_format` is 'html' and `engine` is 'kable'.", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -560,10 +560,10 @@ testthat::test_that("T2.9 No error when `output_format` is 'html' and `engine` i
       output_format = "html",
       engine = "kable"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.10 No error when `output_format` is 'html' and `engine` is 'dt', 'datatable' or 'datatables'.", {
+test_that("T2.10 No error when `output_format` is 'html' and `engine` is 'dt', 'datatable' or 'datatables'.", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -575,7 +575,7 @@ testthat::test_that("T2.10 No error when `output_format` is 'html' and `engine` 
       output_format = "html",
       engine = "dt"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -584,7 +584,7 @@ testthat::test_that("T2.10 No error when `output_format` is 'html' and `engine` 
       output_format = "html",
       engine = "datatable"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -593,10 +593,10 @@ testthat::test_that("T2.10 No error when `output_format` is 'html' and `engine` 
       output_format = "html",
       engine = "datatables"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.11 An error when `output_format` is an invalid parameter.", {
+test_that("T2.11 An error when `output_format` is an invalid parameter.", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -607,7 +607,7 @@ testthat::test_that("T2.11 An error when `output_format` is an invalid parameter
       datasource = NULL,
       output_format = NULL
     ) %>%
-    testthat::expect_error()
+    expect_error()
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -615,7 +615,7 @@ testthat::test_that("T2.11 An error when `output_format` is an invalid parameter
       datasource = NULL,
       output_format = 1
     ) %>%
-    testthat::expect_error()
+    expect_error()
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -623,10 +623,10 @@ testthat::test_that("T2.11 An error when `output_format` is an invalid parameter
       datasource = NULL,
       output_format = "visR"
     ) %>%
-    testthat::expect_error()
+    expect_error()
 })
 
-testthat::test_that("T2.12 An error when `engine` is an invalid parameter.", {
+test_that("T2.12 An error when `engine` is an invalid parameter.", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -637,7 +637,7 @@ testthat::test_that("T2.12 An error when `engine` is an invalid parameter.", {
       datasource = NULL,
       engine = NULL
     ) %>%
-    testthat::expect_error()
+    expect_error()
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -645,7 +645,7 @@ testthat::test_that("T2.12 An error when `engine` is an invalid parameter.", {
       datasource = NULL,
       engine = 1
     ) %>%
-    testthat::expect_error()
+    expect_error()
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -653,10 +653,10 @@ testthat::test_that("T2.12 An error when `engine` is an invalid parameter.", {
       datasource = NULL,
       engine = "visR"
     ) %>%
-    testthat::expect_error()
+    expect_error()
 })
 
-testthat::test_that("T2.13 No error when `output_format` is 'latex' and `engine` is 'kable'.", {
+test_that("T2.13 No error when `output_format` is 'latex' and `engine` is 'kable'.", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -668,10 +668,10 @@ testthat::test_that("T2.13 No error when `output_format` is 'latex' and `engine`
       output_format = "latex",
       engine = "kable"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.14 An error when `output_format` is 'latex' and `engine` is 'dt', 'datatable' or 'datatables'.", {
+test_that("T2.14 An error when `output_format` is 'latex' and `engine` is 'dt', 'datatable' or 'datatables'.", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -683,7 +683,7 @@ testthat::test_that("T2.14 An error when `output_format` is 'latex' and `engine`
       output_format = "latex",
       engine = "dt"
     ) %>%
-    testthat::expect_error()
+    expect_error()
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -692,7 +692,7 @@ testthat::test_that("T2.14 An error when `output_format` is 'latex' and `engine`
       output_format = "latex",
       engine = "datatable"
     ) %>%
-    testthat::expect_error()
+    expect_error()
 
   adtte_risktable %>%
     visR:::render.risktable(
@@ -701,10 +701,10 @@ testthat::test_that("T2.14 An error when `output_format` is 'latex' and `engine`
       output_format = "latex",
       engine = "datatables"
     ) %>%
-    testthat::expect_error()
+    expect_error()
 })
 
-testthat::test_that("T2.15 No error when `engine` is in ['dt', 'datatable', 'datatables'] and download_format` is in ['copy', 'csv', 'excel'].", {
+test_that("T2.15 No error when `engine` is in ['dt', 'datatable', 'datatables'] and download_format` is in ['copy', 'csv', 'excel'].", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -718,12 +718,12 @@ testthat::test_that("T2.15 No error when `engine` is in ['dt', 'datatable', 'dat
           engine = engine,
           download_format = download_format
         ) %>%
-        testthat::expect_error(NA)
+        expect_error(NA)
     }
   }
 })
 
-testthat::test_that("T2.16 A warning when `engine` is not in ['dt', 'datatable', 'datatables'] and download_format` is in ['copy', 'csv', 'excel'].", {
+test_that("T2.16 A warning when `engine` is not in ['dt', 'datatable', 'datatables'] and download_format` is in ['copy', 'csv', 'excel'].", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -737,12 +737,12 @@ testthat::test_that("T2.16 A warning when `engine` is not in ['dt', 'datatable',
           engine = engine,
           download_format = download_format
         ) %>%
-        testthat::expect_warning()
+        expect_warning()
     }
   }
 })
 
-testthat::test_that("T2.17 The strata-colnames of the `risktable` object are used as rownames.", {
+test_that("T2.17 The strata-colnames of the `risktable` object are used as rownames.", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -753,10 +753,10 @@ testthat::test_that("T2.17 The strata-colnames of the `risktable` object are use
 
   strata_names <- colnames(adtte_risktable)[3:length(colnames(adtte_risktable))]
 
-  testthat::expect_identical(strata_names, gg_data[, 1])
+  expect_identical(strata_names, gg_data[, 1])
 })
 
-testthat::test_that("T2.18 The metric of the risktable is used in the rendered table.", {
+test_that("T2.18 The metric of the risktable is used in the rendered table.", {
   adtte_risktable_at_risk <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable(statlist = "n.risk")
@@ -781,12 +781,12 @@ testthat::test_that("T2.18 The metric of the risktable is used in the rendered t
     visR:::render.risktable(title = NULL, datasource = NULL)
   gg_events_data <- gg_events["_data"] %>% as.data.frame()
 
-  testthat::expect_identical(levels(gg_at_risk_data[, 2]), "At risk")
-  testthat::expect_identical(levels(gg_censored_data[, 2]), "Censored")
-  testthat::expect_identical(levels(gg_events_data[, 2]), "Events")
+  expect_identical(levels(gg_at_risk_data[, 2]), "At risk")
+  expect_identical(levels(gg_censored_data[, 2]), "Censored")
+  expect_identical(levels(gg_events_data[, 2]), "Events")
 })
 
-testthat::test_that("T2.19 The values of the evalutated metric are pivoted wide.", {
+test_that("T2.19 The values of the evalutated metric are pivoted wide.", {
   adtte_risktable <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::get_risktable()
@@ -797,15 +797,15 @@ testthat::test_that("T2.19 The values of the evalutated metric are pivoted wide.
   female_vals <- as.numeric(t(gg_data)[3:length(gg_data), 1])
   male_vals <- as.numeric(t(gg_data)[3:length(gg_data), 2])
 
-  testthat::expect_identical(adtte_risktable[, "F"], female_vals)
-  testthat::expect_identical(adtte_risktable[, "M"], male_vals)
+  expect_identical(adtte_risktable[, "F"], female_vals)
+  expect_identical(adtte_risktable[, "M"], male_vals)
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("render - T3. The function `render.data.frame()` properly renders a `data.frame` object.")
+context("render - T3. The function `render.data.frame()` properly renders a `data.frame` object.")
 
-testthat::test_that("T3.1 When `engine` is 'gt' and `output_format` is 'latex', a latex `knit_asis` object is returned.", {
+test_that("T3.1 When `engine` is 'gt' and `output_format` is 'latex', a latex `knit_asis` object is returned.", {
   latex_table <- adtte %>%
     visR:::render.data.frame(
       title = NULL,
@@ -814,10 +814,10 @@ testthat::test_that("T3.1 When `engine` is 'gt' and `output_format` is 'latex', 
       output_format = "latex"
     )
 
-  testthat::expect_true(inherits(latex_table, "knit_asis"))
+  expect_true(inherits(latex_table, "knit_asis"))
 })
 
-testthat::test_that("T3.2 A warning when `engine` is 'dt', 'datatable' or 'datatables' and `output_format is not 'html'.`", {
+test_that("T3.2 A warning when `engine` is 'dt', 'datatable' or 'datatables' and `output_format is not 'html'.`", {
   expected_warning <- "DT engine only supports html output and not latex - falling back to html. Please pick a different engine to create other outputs"
   adtte %>%
     visR:::render.data.frame(
@@ -826,7 +826,7 @@ testthat::test_that("T3.2 A warning when `engine` is 'dt', 'datatable' or 'datat
       engine = "dt",
       output_format = "latex"
     ) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 
   adtte %>%
     visR:::render.data.frame(
@@ -835,7 +835,7 @@ testthat::test_that("T3.2 A warning when `engine` is 'dt', 'datatable' or 'datat
       engine = "datatable",
       output_format = "latex"
     ) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 
   adtte %>%
     visR:::render.data.frame(
@@ -844,74 +844,74 @@ testthat::test_that("T3.2 A warning when `engine` is 'dt', 'datatable' or 'datat
       engine = "datatables",
       output_format = "latex"
     ) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 })
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("render - T4. The function `check_rendering_input()` only permits valid `output_format` and `engine` options.")
+context("render - T4. The function `check_rendering_input()` only permits valid `output_format` and `engine` options.")
 
-testthat::test_that("T4.1 No error when `output_format` is `html` or `latex` and `engine` is `kable`, `gt`, `dt`, `datatable` or `datatables`.", {
+test_that("T4.1 No error when `output_format` is `html` or `latex` and `engine` is `kable`, `gt`, `dt`, `datatable` or `datatables`.", {
   for (output_format in c("html", "latex")) {
     for (engine in c("kable", "gt", "dt", "datatable", "datatables")) {
       visR:::check_rendering_input(
         output_format = output_format,
         engine = engine
       ) %>%
-        testthat::expect_error(NA)
+        expect_error(NA)
     }
   }
 })
 
-testthat::test_that("T4.2 An error when `output_format` and/or `engine` are missing, `NULL` or `NA`.", {
+test_that("T4.2 An error when `output_format` and/or `engine` are missing, `NULL` or `NA`.", {
   arg_missing_waring <- "Please provide an output_format and an engine."
   visR:::check_rendering_input(output_format = "visR") %>%
-    testthat::expect_error(arg_missing_waring)
+    expect_error(arg_missing_waring)
   visR:::check_rendering_input(engine = "visR") %>%
-    testthat::expect_error(arg_missing_waring)
+    expect_error(arg_missing_waring)
   visR:::check_rendering_input(output_format = "html", engine = NULL) %>%
-    testthat::expect_error(arg_missing_waring)
+    expect_error(arg_missing_waring)
   visR:::check_rendering_input(engine = "kable", output_format = NULL) %>%
-    testthat::expect_error(arg_missing_waring)
+    expect_error(arg_missing_waring)
   visR:::check_rendering_input(engine = NULL, output_format = NULL) %>%
-    testthat::expect_error(arg_missing_waring)
+    expect_error(arg_missing_waring)
 
   expected_error <- "Currently implemented output engines are kable, gt and jquery datatables \\(DT\\). NA is not yet supported."
   visR:::check_rendering_input(output_format = "html", engine = NA) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 
   expected_error <- "Currently supported output formats are html and latex. NA is not yet supported."
   visR:::check_rendering_input(engine = "kable", output_format = NA) %>%
-    testthat::expect_error()
+    expect_error()
 })
 
-testthat::test_that("T4.3 An error when `output_format` is not `html` or `latex` and `engine` is a valid option.", {
+test_that("T4.3 An error when `output_format` is not `html` or `latex` and `engine` is a valid option.", {
   expected_error <- "Currently supported output formats are html and latex. visR is not yet supported."
   visR:::check_rendering_input(engine = "kable", output_format = "visR") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T4.4 An error when `engine` is not `kable`, `gt`, `dt`, `datatables` or `datatable` and `output_format` is a valid option.", {
+test_that("T4.4 An error when `engine` is not `kable`, `gt`, `dt`, `datatables` or `datatable` and `output_format` is a valid option.", {
   expected_error <- "Currently implemented output engines are kable, gt and jquery datatables \\(DT\\). visR is not yet supported."
   visR:::check_rendering_input(output_format = "html", engine = "visR") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("render - T5. The function `render_datatable.data.frame()` creates an `htmlwidget` of the table.")
+context("render - T5. The function `render_datatable.data.frame()` creates an `htmlwidget` of the table.")
 
-testthat::test_that("T5.1 No error when `data` is a `data.frame`.", {
+test_that("T5.1 No error when `data` is a `data.frame`.", {
   adtte %>%
     visR:::render_datatable.data.frame(
       title = "visR",
       download_format = "csv",
       source_cap = "visR"
     ) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T5.2 The returned object is of type `htmlwidget`.", {
+test_that("T5.2 The returned object is of type `htmlwidget`.", {
   tmp <- adtte %>%
     visR:::render_datatable.data.frame(
       title = "visR_title",
@@ -919,10 +919,10 @@ testthat::test_that("T5.2 The returned object is of type `htmlwidget`.", {
       source_cap = "visR_source_cap"
     )
 
-  testthat::expect_true(inherits(tmp, "htmlwidget"))
+  expect_true(inherits(tmp, "htmlwidget"))
 })
 
-testthat::test_that("T5.3 The `title` is passed along to the HTML widget.", {
+test_that("T5.3 The `title` is passed along to the HTML widget.", {
   widget_title <- "visR_title"
 
   tmp <- adtte %>%
@@ -932,10 +932,10 @@ testthat::test_that("T5.3 The `title` is passed along to the HTML widget.", {
       source_cap = "visR_source_cap"
     )
 
-  testthat::expect_true(grepl(widget_title, tmp$x$caption))
+  expect_true(grepl(widget_title, tmp$x$caption))
 })
 
-testthat::test_that("T5.4 The `source_cap` is passed along to the HTML widget.", {
+test_that("T5.4 The `source_cap` is passed along to the HTML widget.", {
   source_cap <- "visR_source_cap"
 
   tmp <- adtte %>%
@@ -945,10 +945,10 @@ testthat::test_that("T5.4 The `source_cap` is passed along to the HTML widget.",
       source_cap = source_cap
     )
 
-  testthat::expect_true(grepl(source_cap, tmp$x$options$drawCallback))
+  expect_true(grepl(source_cap, tmp$x$options$drawCallback))
 })
 
-testthat::test_that("T5.5 When `download_format` is not `NULL`, a button is added.", {
+test_that("T5.5 When `download_format` is not `NULL`, a button is added.", {
   download_format <- "visR_csv"
 
   tmp <- adtte %>%
@@ -958,10 +958,10 @@ testthat::test_that("T5.5 When `download_format` is not `NULL`, a button is adde
       source_cap = "visR_source_cap"
     )
 
-  testthat::expect_equal(tmp$x$options$buttons[[1]], download_format)
+  expect_equal(tmp$x$options$buttons[[1]], download_format)
 })
 
-testthat::test_that("T5.6 When `download_format` is `NULL`, no button is added.", {
+test_that("T5.6 When `download_format` is `NULL`, no button is added.", {
   tmp <- adtte %>%
     visR:::render_datatable.data.frame(
       title = "visR_title",
@@ -969,24 +969,24 @@ testthat::test_that("T5.6 When `download_format` is `NULL`, no button is added."
       source_cap = "visR_source_cap"
     )
 
-  testthat::expect_false("buttons" %in% names(tmp$x$options))
+  expect_false("buttons" %in% names(tmp$x$options))
 })
 
 # Requirement T6 ---------------------------------------------------------------
 
-testthat::context("render - T6. The function `get_gt.data.frame()` properly passes the input along to `gt::gt()`.")
+context("render - T6. The function `get_gt.data.frame()` properly passes the input along to `gt::gt()`.")
 
-testthat::test_that("T6.1 No error when `data` is a `data.frame`.", {
+test_that("T6.1 No error when `data` is a `data.frame`.", {
   adtte %>%
     visR:::get_gt.data.frame() %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T6.2 The returned object is of type `gt_tbl`.", {
+test_that("T6.2 The returned object is of type `gt_tbl`.", {
   tmp <- adtte %>%
     visR:::get_gt.data.frame()
 
-  testthat::expect_true(inherits(tmp, "gt_tbl"))
+  expect_true(inherits(tmp, "gt_tbl"))
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-stat_stepribbon.R
+++ b/tests/testthat/test-stat_stepribbon.R
@@ -13,7 +13,7 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("stat_stepribbon - T1. visR::stat_stepribbon() accepts aes() args ymin and ymax.")
+context("stat_stepribbon - T1. visR::stat_stepribbon() accepts aes() args ymin and ymax.")
 
 test_that("T1.1 visR::stat_stepribbon() inherits aes from ggplot()", {
   survfit_tidy <-
@@ -21,7 +21,7 @@ test_that("T1.1 visR::stat_stepribbon() inherits aes from ggplot()", {
     survival::survfit0() %>%
     broom::tidy()
 
-  testthat::expect_error(
+  expect_error(
     gg_step1 <-
       survfit_tidy %>%
       ggplot2::ggplot(ggplot2::aes(x = time, y = estimate, ymin = conf.low, ymax = conf.high)) +
@@ -31,7 +31,7 @@ test_that("T1.1 visR::stat_stepribbon() inherits aes from ggplot()", {
   )
   vdiffr::expect_doppelganger("geom_ribbon-stepribbon-ggplot-aes", gg_step1)
 
-  testthat::expect_error(
+  expect_error(
     gg_step2 <-
       survfit_tidy %>%
       ggplot2::ggplot(ggplot2::aes(x = time, y = estimate, ymin = conf.low, ymax = conf.high)) +
@@ -48,7 +48,7 @@ test_that("T1.2 visR::stat_stepribbon() respects aes from visR::stat_stepribbon(
     survival::survfit0() %>%
     broom::tidy()
 
-  testthat::expect_error(
+  expect_error(
     gg_step1 <-
       survfit_tidy %>%
       ggplot2::ggplot(ggplot2::aes(x = time, y = estimate)) +
@@ -59,7 +59,7 @@ test_that("T1.2 visR::stat_stepribbon() respects aes from visR::stat_stepribbon(
   )
   vdiffr::expect_doppelganger("geom_ribbon-stepribbon-geom_ribbon-aes", gg_step1)
 
-  testthat::expect_error(
+  expect_error(
     gg_step2 <-
       survfit_tidy %>%
       ggplot2::ggplot(ggplot2::aes(x = time, y = estimate)) +
@@ -73,7 +73,7 @@ test_that("T1.2 visR::stat_stepribbon() respects aes from visR::stat_stepribbon(
 
 # Requirement T2 ----------------------------------------------------------
 
-testthat::context("stat_stepribbon - visR::stat_stepribbon() works with the color/fill aesthetic.")
+context("stat_stepribbon - visR::stat_stepribbon() works with the color/fill aesthetic.")
 
 test_that("T2.1 The step ribbon is correctly applied when there are multiple lines from the color/fill aesthetic.", {
   survfit_tidy <-
@@ -81,7 +81,7 @@ test_that("T2.1 The step ribbon is correctly applied when there are multiple lin
     survival::survfit0() %>%
     broom::tidy()
 
-  testthat::expect_error(
+  expect_error(
     gg_step1 <-
       survfit_tidy %>%
       ggplot2::ggplot(ggplot2::aes(x = time, y = estimate,
@@ -96,7 +96,7 @@ test_that("T2.1 The step ribbon is correctly applied when there are multiple lin
 
 # Requirement T3 ----------------------------------------------------------
 
-testthat::context("stat_stepribbon - visR::stat_stepribbon(direction=) argument is respected.")
+context("stat_stepribbon - visR::stat_stepribbon(direction=) argument is respected.")
 
 test_that("T3.1 The visR::stat_stepribbon(direction=) argument is able to produce figures based on both argument options.", {
   survfit_tidy <-
@@ -104,7 +104,7 @@ test_that("T3.1 The visR::stat_stepribbon(direction=) argument is able to produc
     survival::survfit0() %>%
     broom::tidy()
 
-  testthat::expect_error(
+  expect_error(
     gg_step1 <-
       survfit_tidy %>%
       ggplot2::ggplot(ggplot2::aes(x = time, y = estimate,
@@ -116,7 +116,7 @@ test_that("T3.1 The visR::stat_stepribbon(direction=) argument is able to produc
   )
   vdiffr::expect_doppelganger("geom_ribbon-stepribbon-direction-vh", gg_step1)
 
-  testthat::expect_error(
+  expect_error(
     gg_step2 <-
       survfit_tidy %>%
       ggplot2::ggplot(ggplot2::aes(x = time, y = estimate,

--- a/tests/testthat/test-tableone.R
+++ b/tests/testthat/test-tableone.R
@@ -16,98 +16,98 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("tableone - T1. The function accepts a `data.frame` as the main `data` object.")
+context("tableone - T1. The function accepts a `data.frame` as the main `data` object.")
 
-testthat::test_that("T1.1 No error when `data` is of class `data.frame`.", {
+test_that("T1.1 No error when `data` is of class `data.frame`.", {
   adtte %>%
     visR::tableone(title = NULL, datasource = NULL) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T1.2 An error when `data` is not of class `data.frame`.", {
+test_that("T1.2 An error when `data` is not of class `data.frame`.", {
   1 %>%
     visR::tableone(title = NULL, datasource = NULL) %>%
-    testthat::expect_error()
+    expect_error()
 
   "visR" %>%
     visR::tableone(title = NULL, datasource = NULL) %>%
-    testthat::expect_error()
+    expect_error()
 
   c(1, 2, 3) %>%
     visR::tableone(title = NULL, datasource = NULL) %>%
-    testthat::expect_error()
+    expect_error()
 
   NULL %>%
     visR::tableone(title = NULL, datasource = NULL) %>%
-    testthat::expect_error()
+    expect_error()
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("tableone - T2. The function accepts additional parameters.")
+context("tableone - T2. The function accepts additional parameters.")
 
-testthat::test_that("T2.1 No error when `title` is not `NULL`.", {
+test_that("T2.1 No error when `title` is not `NULL`.", {
   adtte %>%
     visR::tableone(title = 1, datasource = NULL) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::tableone(title = "visR", datasource = NULL) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::tableone(title = c(1, 2, 3), datasource = NULL) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.2 No error when `datasource` is not `NULL`.", {
+test_that("T2.2 No error when `datasource` is not `NULL`.", {
   adtte %>%
     visR::tableone(title = NULL, datasource = 1) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::tableone(title = NULL, datasource = "visR") %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::tableone(title = NULL, datasource = c(1, 2, 3)) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.3 No error when `footnote` is not `NULL`.", {
+test_that("T2.3 No error when `footnote` is not `NULL`.", {
   adtte %>%
     visR::tableone(title = NULL, datasource = NULL, footnote = 1) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::tableone(title = NULL, datasource = NULL, footnote = "visR") %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::tableone(title = NULL, datasource = NULL, footnote = c(1, 2, 3)) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.4 No error when `strata` is not `NULL`.", {
+test_that("T2.4 No error when `strata` is not `NULL`.", {
   adtte %>%
     visR::tableone(title = NULL, datasource = NULL, strata = "SEX") %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.5 No error when `overall` is a `logical`.", {
+test_that("T2.5 No error when `overall` is a `logical`.", {
   adtte %>%
     visR::tableone(title = NULL, datasource = NULL, overall = TRUE) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   adtte %>%
     visR::tableone(title = NULL, datasource = NULL, overall = FALSE) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T2.6 An error when `overall` is not a `logical`.", {
+test_that("T2.6 An error when `overall` is not a `logical`.", {
   adtte %>%
     visR::tableone(title = NULL, datasource = NULL, overall = "visR") %>%
-    testthat::expect_error()
+    expect_error()
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-tidyme.R
+++ b/tests/testthat/test-tidyme.R
@@ -20,48 +20,48 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("tidyme - T1. The function accepts an S3 object")
+context("tidyme - T1. The function accepts an S3 object")
 
-testthat::test_that("T1.1 No error when a `survfit` object is passed to the function", {
+test_that("T1.1 No error when a `survfit` object is passed to the function", {
   survfit_object <- visR::estimate_KM(data = adtte, strata = "TRTA")
-  testthat::expect_error(visR::tidyme(survfit_object), NA)
+  expect_error(visR::tidyme(survfit_object), NA)
 })
 
-testthat::test_that("T1.2 No error when a `survfit` object with missing values is passed to the function", {
+test_that("T1.2 No error when a `survfit` object with missing values is passed to the function", {
   adtte_with_na <- adtte
   is.na(adtte_with_na$SEX[sample(seq_len(nrow(adtte_with_na)), size = 40)]) <- TRUE
 
   survfit_object <- visR::estimate_KM(data = adtte_with_na, strata = "SEX")
-  testthat::expect_error(visR::tidyme(survfit_object), NA)
+  expect_error(visR::tidyme(survfit_object), NA)
 })
 
-testthat::test_that("T1.3 No error when a non-`survfit` S3 object is passed to the function", {
+test_that("T1.3 No error when a non-`survfit` S3 object is passed to the function", {
   lm_object <- stats::lm(data = adtte, TRTDUR ~ AVAL)
-  testthat::expect_error(visR::tidyme(lm_object), NA)
+  expect_error(visR::tidyme(lm_object), NA)
 })
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("tidyme - T2. The function tidies up an associated object")
+context("tidyme - T2. The function tidies up an associated object")
 
-testthat::test_that("T2.1 The default method throws a message to indicate it relies on broom::tidy", {
+test_that("T2.1 The default method throws a message to indicate it relies on broom::tidy", {
   lm_object <- stats::lm(data = adtte, TRTDUR ~ AVAL)
 
-  testthat::expect_message(visR::tidyme(lm_object))
+  expect_message(visR::tidyme(lm_object))
 })
 
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("tidyme - T3. The S3 method, associated with a `survfit` object, outputs an extended tidied data.frame")
+context("tidyme - T3. The S3 method, associated with a `survfit` object, outputs an extended tidied data.frame")
 
-testthat::test_that("T3.1 The S3 method, associated with a `survfit` object, returns a data.frame", {
+test_that("T3.1 The S3 method, associated with a `survfit` object, returns a data.frame", {
   survfit_object <- visR::estimate_KM(data = adtte, strata = "TRTA")
   survfit_object_tidy <- tidyme(survfit_object)
-  testthat::expect_true(inherits(survfit_object_tidy, "data.frame"))
+  expect_true(inherits(survfit_object_tidy, "data.frame"))
 })
 
-testthat::test_that("T3.2 The S3 method, associated with a `survfit` object, has columns representing all list elements of the S3 object", {
+test_that("T3.2 The S3 method, associated with a `survfit` object, has columns representing all list elements of the S3 object", {
   survfit_object <- visR::estimate_KM(data = adtte, strata = "TRTA")
   survfit_object_tidy <- tidyme(survfit_object)
 
@@ -135,53 +135,53 @@ testthat::test_that("T3.2 The S3 method, associated with a `survfit` object, has
   colnames(surv_object_df)
 
   # not checking call because it's a quo with an env attached, and matching the env is ¯\_(ツ)_/¯
-  testthat::expect_equal(
+  expect_equal(
     surv_object_df %>% dplyr::select(-call),
     survfit_object_tidy %>% dplyr::select(-call),
     check.attributes = FALSE
   )
 })
 
-testthat::test_that("T3.3 The S3 method, associated with a `survfit` object, turns list elements that represent integer numbers into integers", {
+test_that("T3.3 The S3 method, associated with a `survfit` object, turns list elements that represent integer numbers into integers", {
   survfit_object <- visR::estimate_KM(data = adtte, strata = "TRTA")
   survfit_object_tidy <- tidyme(survfit_object)
 
-  testthat::expect_true(inherits(survfit_object_tidy[["n.risk"]], "integer"))
-  testthat::expect_true(inherits(survfit_object_tidy[["n.censor"]], "integer"))
-  testthat::expect_true(inherits(survfit_object_tidy[["n.event"]], "integer"))
-  testthat::expect_true(inherits(survfit_object_tidy[["n.strata"]], "integer"))
+  expect_true(inherits(survfit_object_tidy[["n.risk"]], "integer"))
+  expect_true(inherits(survfit_object_tidy[["n.censor"]], "integer"))
+  expect_true(inherits(survfit_object_tidy[["n.event"]], "integer"))
+  expect_true(inherits(survfit_object_tidy[["n.strata"]], "integer"))
 })
 
-testthat::test_that("T3.4 The S3 method, assocated with a `survfit` object, turns the strata into a factor", {
+test_that("T3.4 The S3 method, assocated with a `survfit` object, turns the strata into a factor", {
   dt <- adtte
   dt[["TRTA"]] <- factor(dt[["TRTA"]], levels = c("Xanomeline Low Dose", "Xanomeline High Dose", "Placebo"))
 
   survfit_object <- visR::estimate_KM(data = dt, strata = "TRTA")
   survfit_object_tidy <- tidyme(survfit_object)
 
-  testthat::expect_true(inherits(survfit_object_tidy[["strata"]], "factor"))
-  testthat::expect_equal(levels(survfit_object_tidy[["strata"]]), paste0(levels(dt$TRTA)))
+  expect_true(inherits(survfit_object_tidy[["strata"]], "factor"))
+  expect_equal(levels(survfit_object_tidy[["strata"]]), paste0(levels(dt$TRTA)))
 })
 
-testthat::test_that("T3.5 The S3 method, associated with a `survfit` object, add the original object as an attribute to the tidied object", {
+test_that("T3.5 The S3 method, associated with a `survfit` object, add the original object as an attribute to the tidied object", {
   survobj <- visR::estimate_KM(adtte, strata = "TRTA")
   visr_tidy <- visR::tidyme(survobj)
 
-  testthat::expect_equal(attributes(visr_tidy)[["survfit_object"]], survobj)
+  expect_equal(attributes(visr_tidy)[["survfit_object"]], survobj)
 })
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("tidyme - T4. The S3 method, associated with a `survfit` object ensures compatibility with broom-dependent workflows")
+context("tidyme - T4. The S3 method, associated with a `survfit` object ensures compatibility with broom-dependent workflows")
 
-testthat::test_that("T4.1 The S3 method, associated with a `survfit` object, copies content to columns with the nomenclature used in broom::tidy", {
+test_that("T4.1 The S3 method, associated with a `survfit` object, copies content to columns with the nomenclature used in broom::tidy", {
   survobj <- visR::estimate_KM(adtte, strata = "TRTA")
   visr_tidy <- visR::tidyme(survobj)
   broom_tidy <- as.data.frame(broom::tidy(survobj))
   have <- names(visr_tidy)
   want <- names(broom_tidy)
 
-  testthat::expect_true(any(want %in% have))
+  expect_true(any(want %in% have))
 
   # construct df for testthat check
   test_df <- data.frame(
@@ -192,7 +192,7 @@ testthat::test_that("T4.1 The S3 method, associated with a `survfit` object, cop
     dplyr::rowwise() %>%
     dplyr::mutate(rowwise_sd = sd(dplyr::c_across(A:C)))
 
-  testthat::expect_true(all(test_df$rowwise_sd == 0))
+  expect_true(all(test_df$rowwise_sd == 0))
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-utils_general.R
+++ b/tests/testthat/test-utils_general.R
@@ -10,29 +10,29 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("utils_general - T1. The input number is correctly formatted.")
+context("utils_general - T1. The input number is correctly formatted.")
 
-testthat::test_that("T1.1 Numbers smaller than 0.001 return the string '<0.001'.", {
+test_that("T1.1 Numbers smaller than 0.001 return the string '<0.001'.", {
   input <- 0.0001
   output <- visR:::.pvalformat(input)
-  testthat::expect_identical(output, "<0.001")
+  expect_identical(output, "<0.001")
 })
 
-testthat::test_that("T1.2 Numbers greater than 0.999 return the string '>0.999'.", {
+test_that("T1.2 Numbers greater than 0.999 return the string '>0.999'.", {
   input <- 0.9999
   output <- visR:::.pvalformat(input)
-  testthat::expect_identical(output, ">0.999")
+  expect_identical(output, ">0.999")
 })
 
-testthat::test_that("T1.3 A number in \\[0.001, 0.999\\] is rounded to a precision of 3 with a total width of 6 characters.", {
+test_that("T1.3 A number in \\[0.001, 0.999\\] is rounded to a precision of 3 with a total width of 6 characters.", {
   input <- 0.314159
   output <- visR:::.pvalformat(input)
 
   # Precision
-  testthat::expect_true(base::nchar(base::strsplit(output, "\\.")[[1]][2]) == 3)
+  expect_true(base::nchar(base::strsplit(output, "\\.")[[1]][2]) == 3)
 
   # Total width
-  testthat::expect_true(base::nchar(output) == 6)
+  expect_true(base::nchar(output) == 6)
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-utils_table.R
+++ b/tests/testthat/test-utils_table.R
@@ -12,53 +12,53 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("utils_table - T1. Correct values for summarize_long.numeric")
+context("utils_table - T1. Correct values for summarize_long.numeric")
 
 test_that("T1.1. Correct mean values for numeric values", {
   values <- 1:5
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$mean, mean(values))
+  expect_equal(summary[[1]]$mean, mean(values))
 })
 
 test_that("T1.2. Correct min value for numeric values", {
   values <- 1:5
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$min, min(values))
+  expect_equal(summary[[1]]$min, min(values))
 })
 
 test_that("T1.3. Correct max value for numeric values", {
   values <- 1:5
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$max, max(values))
+  expect_equal(summary[[1]]$max, max(values))
 })
 
 test_that("T1.4. Correct Q1 value for numeric values", {
   values <- 1:5
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$Q1, stats::quantile(values)[2])
+  expect_equal(summary[[1]]$Q1, stats::quantile(values)[2])
 })
 
 test_that("T1.5. Correct Q3 value for numeric values", {
   values <- 1:5
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$Q3, stats::quantile(values)[4])
+  expect_equal(summary[[1]]$Q3, stats::quantile(values)[4])
 })
 
 test_that("T1.6. Correct SD value for numeric values", {
   values <- 1:5
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$sd, stats::sd(values))
+  expect_equal(summary[[1]]$sd, stats::sd(values))
 })
 
 test_that("T1.7. Correct median value for numeric values", {
   values <- 1:5
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$median, stats::median(values))
+  expect_equal(summary[[1]]$median, stats::median(values))
 })
 
 test_that("T1.8. Integers as correctly dispatched to summarize_long.numeric", {
   values <- 1:5
-  testthat::expect_equal(
+  expect_equal(
     visR::summarize_long(values),
     visR::summarize_long(as.integer(values))
   )
@@ -66,18 +66,18 @@ test_that("T1.8. Integers as correctly dispatched to summarize_long.numeric", {
 
 # Requirement T2 ---------------------------------------------------------------
 
-testthat::context("utils_table - T2. Correct values for summarize_long.factors")
+context("utils_table - T2. Correct values for summarize_long.factors")
 
 test_that("T2.1. Correct count of factor values", {
   values <- as.factor(c("A", "A", "B"))
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$`N A`, sum(values == "A"))
+  expect_equal(summary[[1]]$`N A`, sum(values == "A"))
 })
 
 test_that("T2.2. Correct perentage of factor values", {
   values <- as.factor(c("A", "A", "B"))
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(
+  expect_equal(
     round(summary[[1]]$`% A`, 2),
     round((sum(values == "A") / length(values)) * 100, 2)
   )
@@ -86,23 +86,23 @@ test_that("T2.2. Correct perentage of factor values", {
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("utils_table - T3. Correct values for summarize_long.default")
+context("utils_table - T3. Correct values for summarize_long.default")
 
 test_that("T3.1. Correct count of unique values", {
   values <- c("A", "A", "B")
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$unique_values, length(unique(values)))
+  expect_equal(summary[[1]]$unique_values, length(unique(values)))
 })
 
 test_that("T3.1. Correct count of missing values", {
   values <- c("A", "A", "B")
   summary <- visR::summarize_long(values)
-  testthat::expect_equal(summary[[1]]$nmiss, 0)
+  expect_equal(summary[[1]]$nmiss, 0)
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("utils_table - T4. Correct values for summarize_short.numeric")
+context("utils_table - T4. Correct values for summarize_short.numeric")
 
 test_that("T4.1. Correct mean values for numeric values in summarize_short", {
   values <- 1:5
@@ -113,7 +113,7 @@ test_that("T4.1. Correct mean values for numeric values in summarize_short", {
     round(stats::sd(values), 2),
     ")"
   )
-  testthat::expect_equal(summary[[1]]$`Mean (SD)`, num)
+  expect_equal(summary[[1]]$`Mean (SD)`, num)
 })
 
 test_that("T4.2. Correct median values for numeric values in summarize_short", {
@@ -127,7 +127,7 @@ test_that("T4.2. Correct median values for numeric values in summarize_short", {
     round(stats::quantile(values, probs = 0.75, na.rm = TRUE), 2),
     ")"
   )
-  testthat::expect_equal(summary[[1]]$`Median (IQR)`, num)
+  expect_equal(summary[[1]]$`Median (IQR)`, num)
 })
 
 test_that("T4.3. Correct range values for numeric values in summarize_short", {
@@ -138,7 +138,7 @@ test_that("T4.3. Correct range values for numeric values in summarize_short", {
     "-",
     round(max(values), 2)
   )
-  testthat::expect_equal(summary[[1]]$`Min-max`, num)
+  expect_equal(summary[[1]]$`Min-max`, num)
 })
 
 
@@ -149,12 +149,12 @@ test_that("T4.4. Correct missing values for numeric values in summarize_short", 
     sum(is.na(values)), " (",
     sum(is.na(values)) / length(values), "%)"
   )
-  testthat::expect_equal(summary[[1]]$Missing, num)
+  expect_equal(summary[[1]]$Missing, num)
 })
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("utils_table - T5. Correct values for summarize_short.factor and summarize_short.string")
+context("utils_table - T5. Correct values for summarize_short.factor and summarize_short.string")
 
 test_that("T5.1. Correct value for factors in summarize_short", {
   values <- as.factor(c("A", "A", "B"))
@@ -163,7 +163,7 @@ test_that("T5.1. Correct value for factors in summarize_short", {
     sum(values == "A"), " (",
     round(sum(values == "A") / length(values) * 100, 1), "%)"
   )
-  testthat::expect_equal(summary[[1]]$A, num)
+  expect_equal(summary[[1]]$A, num)
 })
 
 test_that("T5.2. Correct default value in summarize_short", {
@@ -173,7 +173,7 @@ test_that("T5.2. Correct default value in summarize_short", {
     sum(values == "A"), " (",
     round(sum(values == "A") / length(values) * 100, 1), "%)"
   )
-  testthat::expect_equal(
+  expect_equal(
     summary[[1]]$`Unique values`,
     as.character(sum(values == "A"))
   )

--- a/tests/testthat/test-utils_visR.R
+++ b/tests/testthat/test-utils_visR.R
@@ -143,297 +143,297 @@ testthat::test_that("T2.4 The final plot shows aligned plots taking the legend i
     visR::visr() %>%
     add_risktable(group = "statlist")
 
-  testthat::skip_on_cran()
+  skip_on_cran()
   gg_sex_trtp %>%
     vdiffr::expect_doppelganger(title = "utils_visr_T2_4_yaxis_labels_aligned_when_legend")
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("utils_visr - T3. The function `legendopts()` translates the input to a `ggplot2`-compatible list.")
+context("utils_visr - T3. The function `legendopts()` translates the input to a `ggplot2`-compatible list.")
 
-testthat::test_that("T3.1 No error when no arguments are specified.", {
-  testthat::expect_error(visR:::legendopts(), NA)
+test_that("T3.1 No error when no arguments are specified.", {
+  expect_error(visR:::legendopts(), NA)
 })
 
-testthat::test_that("T3.2 A list is returned when no arguments are specified.", {
+test_that("T3.2 A list is returned when no arguments are specified.", {
   opts <- visR:::legendopts()
 
-  testthat::expect_true(inherits(opts, "list"))
+  expect_true(inherits(opts, "list"))
 })
 
-testthat::test_that("T3.3 No error when `legend_position` is 'bottom', 'right', 'top', 'left' or 'none'.", {
+test_that("T3.3 No error when `legend_position` is 'bottom', 'right', 'top', 'left' or 'none'.", {
   for (pos in c("bottom", "right", "top", "left", "none")) {
-    testthat::expect_error(visR:::legendopts(legend_position = pos), NA)
+    expect_error(visR:::legendopts(legend_position = pos), NA)
   }
 })
 
-testthat::test_that("T3.4 When `legend_position` is 'bottom' and `legend_orientation` is `NULL`, the parameters in the returned object anchor it bottom-centered.", {
+test_that("T3.4 When `legend_position` is 'bottom' and `legend_orientation` is `NULL`, the parameters in the returned object anchor it bottom-centered.", {
   legend <- visR:::legendopts(
     legend_position = "bottom",
     legend_orientation = NULL
   )
 
-  testthat::expect_true(legend$leg_opts$xanchor == "center")
-  testthat::expect_true(legend$leg_opts$x == 0.5)
-  testthat::expect_true(legend$leg_opts$y == -0.2)
-  testthat::expect_true(legend$leg_opts$orientation == "h")
-  testthat::expect_true(legend$showlegend == TRUE)
+  expect_true(legend$leg_opts$xanchor == "center")
+  expect_true(legend$leg_opts$x == 0.5)
+  expect_true(legend$leg_opts$y == -0.2)
+  expect_true(legend$leg_opts$orientation == "h")
+  expect_true(legend$showlegend == TRUE)
 })
 
-testthat::test_that("T3.5 When `legend_position` is 'right' and `legend_orientation` is `NULL`, the parameters in the returned object anchor it right-centered.", {
+test_that("T3.5 When `legend_position` is 'right' and `legend_orientation` is `NULL`, the parameters in the returned object anchor it right-centered.", {
   legend <- visR:::legendopts(
     legend_position = "right",
     legend_orientation = NULL
   )
 
-  testthat::expect_true(legend$leg_opts$yanchor == "center")
-  testthat::expect_true(legend$leg_opts$x == 1.2)
-  testthat::expect_true(legend$leg_opts$y == 0.5)
-  testthat::expect_true(legend$leg_opts$orientation == "v")
-  testthat::expect_true(legend$showlegend == TRUE)
+  expect_true(legend$leg_opts$yanchor == "center")
+  expect_true(legend$leg_opts$x == 1.2)
+  expect_true(legend$leg_opts$y == 0.5)
+  expect_true(legend$leg_opts$orientation == "v")
+  expect_true(legend$showlegend == TRUE)
 })
 
-testthat::test_that("T3.6 When `legend_position` is 'top' and `legend_orientation` is `NULL`, the parameters in the returned object anchor it top-centered.", {
+test_that("T3.6 When `legend_position` is 'top' and `legend_orientation` is `NULL`, the parameters in the returned object anchor it top-centered.", {
   legend <- visR:::legendopts(
     legend_position = "top",
     legend_orientation = NULL
   )
 
-  testthat::expect_true(legend$leg_opts$xanchor == "center")
-  testthat::expect_true(legend$leg_opts$x == 0.5)
-  testthat::expect_true(legend$leg_opts$y == 1.2)
-  testthat::expect_true(legend$leg_opts$orientation == "h")
-  testthat::expect_true(legend$showlegend == TRUE)
+  expect_true(legend$leg_opts$xanchor == "center")
+  expect_true(legend$leg_opts$x == 0.5)
+  expect_true(legend$leg_opts$y == 1.2)
+  expect_true(legend$leg_opts$orientation == "h")
+  expect_true(legend$showlegend == TRUE)
 })
 
-testthat::test_that("T3.7 When `legend_position` is 'left' and `legend_orientation` is `NULL`, the parameters in the returned object anchor it left-centered.", {
+test_that("T3.7 When `legend_position` is 'left' and `legend_orientation` is `NULL`, the parameters in the returned object anchor it left-centered.", {
   legend <- visR:::legendopts(
     legend_position = "left",
     legend_orientation = NULL
   )
 
-  testthat::expect_true(legend$leg_opts$yanchor == "center")
-  testthat::expect_true(legend$leg_opts$x == -1.0)
-  testthat::expect_true(legend$leg_opts$y == 0.5)
-  testthat::expect_true(legend$leg_opts$orientation == "v")
-  testthat::expect_true(legend$showlegend == TRUE)
+  expect_true(legend$leg_opts$yanchor == "center")
+  expect_true(legend$leg_opts$x == -1.0)
+  expect_true(legend$leg_opts$y == 0.5)
+  expect_true(legend$leg_opts$orientation == "v")
+  expect_true(legend$showlegend == TRUE)
 })
 
-testthat::test_that("T3.8 When `legend_position` is 'none', the parameters in the returned object disable the legend.", {
+test_that("T3.8 When `legend_position` is 'none', the parameters in the returned object disable the legend.", {
   legend <- visR:::legendopts(
     legend_position = "none",
     legend_orientation = NULL
   )
 
-  testthat::expect_true(is.null(legend$leg_opts))
-  testthat::expect_false(legend$showlegend)
+  expect_true(is.null(legend$leg_opts))
+  expect_false(legend$showlegend)
 })
 
-testthat::test_that("T3.9 When `legend_orientation` is not `NULL`, it is used as `$leg_opts$orientation` in the returned object.", {
+test_that("T3.9 When `legend_orientation` is not `NULL`, it is used as `$leg_opts$orientation` in the returned object.", {
   for (orientation in c(1, "visR", c(1, 2, 3))) {
     tmp <- visR:::legendopts(legend_orientation = orientation)
 
-    testthat::expect_equal(orientation, tmp$leg_opts$orientation)
+    expect_equal(orientation, tmp$leg_opts$orientation)
   }
 })
 
-testthat::test_that("T3.10 When `legend_position` is not a character, but a vector with at least length 2, the first two elements are used as x/y positions for the legend.", {
+test_that("T3.10 When `legend_position` is not a character, but a vector with at least length 2, the first two elements are used as x/y positions for the legend.", {
   suppressWarnings(legend <- visR:::legendopts(legend_position = c(1, 2)))
 
-  testthat::expect_true(legend$leg_opts$x == 1)
-  testthat::expect_true(legend$leg_opts$y == 2)
+  expect_true(legend$leg_opts$x == 1)
+  expect_true(legend$leg_opts$y == 2)
 })
 
-testthat::test_that("T3.11 A warning when `legend_position` is a vector with a length greater than 2.", {
+test_that("T3.11 A warning when `legend_position` is a vector with a length greater than 2.", {
   expected_warning <- "The provided vector for the legend position contains more than 2 elements, only using the first two."
   visR:::legendopts(legend_position = c(1, 2, 3)) %>%
-    testthat::expect_warning(expected_warning)
+    expect_warning(expected_warning)
 })
 
-testthat::test_that("T3.12 An error when `legend_position` is not a `character` or a vector with a length of at least 2.", {
-  visR:::legendopts(legend_position = 1) %>% testthat::expect_error()
-  visR:::legendopts(legend_position = c(1)) %>% testthat::expect_error()
-  visR:::legendopts(legend_position = c()) %>% testthat::expect_error()
+test_that("T3.12 An error when `legend_position` is not a `character` or a vector with a length of at least 2.", {
+  visR:::legendopts(legend_position = 1) %>% expect_error()
+  visR:::legendopts(legend_position = c(1)) %>% expect_error()
+  visR:::legendopts(legend_position = c()) %>% expect_error()
 })
 
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("utils_visr - T4. `.convert_alpha` can convert hex-encoded alpha values between its two representations.")
+context("utils_visr - T4. `.convert_alpha` can convert hex-encoded alpha values between its two representations.")
 
-testthat::test_that("T4.1 A two-letter character string is returned when `numeric_alpha` is specified but not `hex_alpha`.", {
+test_that("T4.1 A two-letter character string is returned when `numeric_alpha` is specified but not `hex_alpha`.", {
   visR:::.convert_alpha(numeric_alpha = 0.5) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   res <- visR:::.convert_alpha(numeric_alpha = 0.5)
 
-  testthat::expect_true(nchar(res) == 2)
-  testthat::expect_true(inherits(res, "character"))
+  expect_true(nchar(res) == 2)
+  expect_true(inherits(res, "character"))
 })
 
-testthat::test_that("T4.2 A numeric is returned when `numeric_alpha` is not specified but `hex_alpha`.", {
+test_that("T4.2 A numeric is returned when `numeric_alpha` is not specified but `hex_alpha`.", {
   visR:::.convert_alpha(hex_alpha = "FF") %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
-  testthat::expect_true(inherits(visR:::.convert_alpha(hex_alpha = "FF"), "numeric"))
+  expect_true(inherits(visR:::.convert_alpha(hex_alpha = "FF"), "numeric"))
 })
 
-testthat::test_that("T4.3 An error when `numeric_alpha` and `hex_alpha` are both specified.", {
+test_that("T4.3 An error when `numeric_alpha` and `hex_alpha` are both specified.", {
   expected_error <- "Please choose either `numeric_alpha` or `hex_alpha`."
 
   visR:::.convert_alpha(numeric_alpha = 0.5, hex_alpha = "FF") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T4.4 Ab error when neither `numeric_alpha` nor `hex_alpha` are specified.", {
+test_that("T4.4 Ab error when neither `numeric_alpha` nor `hex_alpha` are specified.", {
   expected_error <- "Either `numeric_alpha` or `hex_alpha` has to be specified."
 
   visR:::.convert_alpha() %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T4.5 No error when `numeric_alpha` is a `numeric` between 0 and 1.", {
+test_that("T4.5 No error when `numeric_alpha` is a `numeric` between 0 and 1.", {
   visR:::.convert_alpha(numeric_alpha = 0.5) %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T4.6 An error when `numeric_alpha` is a `numeric` outside of [0, 1].", {
+test_that("T4.6 An error when `numeric_alpha` is a `numeric` outside of [0, 1].", {
   expected_error <- "Please enter a numeric value between 0 and 1 for `numeric_alpha`."
 
   visR:::.convert_alpha(numeric_alpha = -0.5) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 
   visR:::.convert_alpha(numeric_alpha = 1.5) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T4.7 An error when `numeric_alpha` is not a `numeric`.", {
+test_that("T4.7 An error when `numeric_alpha` is not a `numeric`.", {
   expected_error <- "Please enter a numeric value between 0 and 1 for `numeric_alpha`."
 
   visR:::.convert_alpha(numeric_alpha = "visR") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T4.8 No error when `hex_alpha` is a two-letter character string.", {
+test_that("T4.8 No error when `hex_alpha` is a two-letter character string.", {
   visR:::.convert_alpha(hex_alpha = "FF") %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T4.9 An error when `hex_alpha` is a character string longer than two letters.", {
+test_that("T4.9 An error when `hex_alpha` is a character string longer than two letters.", {
   expected_error <- "Please specify a two-letter character string for `hex_alpha`."
 
   visR:::.convert_alpha(hex_alpha = "visR") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T4.10 When `numeric_alpha` is `NULL` or `NA`, the hex-encoded alpha = 1 (00) is returned.", {
+test_that("T4.10 When `numeric_alpha` is `NULL` or `NA`, the hex-encoded alpha = 1 (00) is returned.", {
   visR:::.convert_alpha(numeric_alpha = NULL) %>%
-    testthat::expect_identical("00")
+    expect_identical("00")
 
   visR:::.convert_alpha(numeric_alpha = NA) %>%
-    testthat::expect_identical("00")
+    expect_identical("00")
 })
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("utils_visr - T5. `.replace_hex_alpha` modified the alpha value of a hex-encoded colour.")
+context("utils_visr - T5. `.replace_hex_alpha` modified the alpha value of a hex-encoded colour.")
 
-testthat::test_that("T5.1 No error when `colour` is a #RRGGBBAA string and `new_alpha` is a two-letter string.", {
+test_that("T5.1 No error when `colour` is a #RRGGBBAA string and `new_alpha` is a two-letter string.", {
   visR:::.replace_hex_alpha(colour = "#FFFFFF00", new_alpha = "FF") %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 })
 
-testthat::test_that("T5.2 An error when either `colour` or `new_alpha` or none of both are specified.", {
+test_that("T5.2 An error when either `colour` or `new_alpha` or none of both are specified.", {
   expected_error <- "Please provide a `colour` and a `new_alpha` in hex representation as strings."
 
   visR:::.replace_hex_alpha(colour = "#FFFFFF00") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 
   visR:::.replace_hex_alpha(new_alpha = "FF") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 
   visR:::.replace_hex_alpha() %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T5.3 An error when `new_alpha` is not a two-character string.", {
+test_that("T5.3 An error when `new_alpha` is not a two-character string.", {
   expected_error <- "Please provide a two-character string for the hex representation of the new alpha."
 
   visR:::.replace_hex_alpha(colour = "#FFFFFF00", new_alpha = 1) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 
   visR:::.replace_hex_alpha(colour = "#FFFFFF00", new_alpha = "visR") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T5.4 An error when `colour` is not a string.", {
+test_that("T5.4 An error when `colour` is not a string.", {
   expected_error <- "Please provide a hex colour as a string."
 
   visR:::.replace_hex_alpha(colour = 1, new_alpha = "FF") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T5.5 An error when `colour` is a string but not in the format of #RRGGBBAA.", {
+test_that("T5.5 An error when `colour` is a string but not in the format of #RRGGBBAA.", {
   expected_error <- "Please provide a hex colour in the format #RRGGBBAA."
 
   # Covers case of too long strings
   visR:::.replace_hex_alpha(colour = "this_string_is_too_long", new_alpha = "FF") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 
   # Covers case of nchar == 9 but no # in first position
   visR:::.replace_hex_alpha(colour = "visRvisRv", new_alpha = "FF") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T5.6 The function replaces the AA part #RRGGBBAA in `colour` with `new_alpha`.", {
+test_that("T5.6 The function replaces the AA part #RRGGBBAA in `colour` with `new_alpha`.", {
   colour <- "#FFFFFFAA"
   new_alpha <- "00"
 
   new_colour <- visR:::.replace_hex_alpha(colour = colour, new_alpha = new_alpha)
 
-  testthat::expect_equal(substr(colour, 1, 7), substr(new_colour, 1, 7))
-  testthat::expect_equal(new_alpha, substr(new_colour, 8, 9))
+  expect_equal(substr(colour, 1, 7), substr(new_colour, 1, 7))
+  expect_equal(new_alpha, substr(new_colour, 8, 9))
 })
 
 # Requirement T6 ---------------------------------------------------------------
 
-testthat::context("utils_visr - T6. `.get_alpha_from_hex_colour` extracts the numerical value of a hex-encoded colour.")
+context("utils_visr - T6. `.get_alpha_from_hex_colour` extracts the numerical value of a hex-encoded colour.")
 
-testthat::test_that("T6.1 A numerical value is returned when `hex_colour` is a #RRGGBBAA `character` string.", {
+test_that("T6.1 A numerical value is returned when `hex_colour` is a #RRGGBBAA `character` string.", {
   visR:::.get_alpha_from_hex_colour(hex_colour = "#FFFFFF04") %>%
-    testthat::expect_error(NA)
+    expect_error(NA)
 
   alpha <- visR:::.get_alpha_from_hex_colour(hex_colour = "#FFFFFF04")
-  testthat::expect_true(inherits(alpha, "numeric"))
+  expect_true(inherits(alpha, "numeric"))
 })
 
-testthat::test_that("T6.2 An error when `hex_color` is misisng", {
+test_that("T6.2 An error when `hex_color` is misisng", {
   expected_error <- "Please provide a colour in hex representation as a string for `hex_colour`."
 
   visR:::.get_alpha_from_hex_colour() %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T6.3 An error when `hex_color` is not a character string.", {
+test_that("T6.3 An error when `hex_color` is not a character string.", {
   expected_error <- "Please provide a colour in hex representation as a string for `hex_colour`."
 
   visR:::.get_alpha_from_hex_colour(hex_colour = 1) %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T6.4 An error when `hex_color` is not a character string with length 9.", {
+test_that("T6.4 An error when `hex_color` is not a character string with length 9.", {
   expected_error <- "Please provide a hex colour in the format #RRGGBBAA."
 
   visR:::.get_alpha_from_hex_colour(hex_colour = "visR") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
-testthat::test_that("T6.5 An error when `hex_color` is a character string with length 9 but doesn't have # at the first position.", {
+test_that("T6.5 An error when `hex_color` is a character string with length 9 but doesn't have # at the first position.", {
   expected_error <- "Please provide a hex colour in the format #RRGGBBAA."
 
   visR:::.get_alpha_from_hex_colour(hex_colour = "visRvisRv") %>%
-    testthat::expect_error(expected_error)
+    expect_error(expected_error)
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-vignettes.R
+++ b/tests/testthat/test-vignettes.R
@@ -8,9 +8,9 @@
 
 # Requirement T1 ----------------------------------------------------------
 
-testthat::context("vignettes - T1. Data loaded from external sources exists.")
+context("vignettes - T1. Data loaded from external sources exists.")
 
-testthat::test_that("T1.1 Data from Bankar et al. is still hosted on GitHub.", {
+test_that("T1.1 Data from Bankar et al. is still hosted on GitHub.", {
 
   # Our interactive vignette loads public data so that people can follow along
   # This test ensures that it is still publicly available
@@ -34,7 +34,7 @@ testthat::test_that("T1.1 Data from Bankar et al. is still hosted on GitHub.", {
     )
   )
 
-  testthat::expect_true(is.null(check))
+  expect_true(is.null(check))
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-visr_attrition.R
+++ b/tests/testthat/test-visr_attrition.R
@@ -49,7 +49,7 @@ testthat::test_that("T1.1 No error when `description_column_name` is a `characte
   testthat::expect_error(attrition_object %>% visR::visr(description_column_name = "Criteria"), NA)
 })
 
-testthat::test_that("T1.2 No error when `value_column_name` is a `character` string that is found in the colnames of the `attrition` object.", {
+test_that("T1.2 No error when `value_column_name` is a `character` string that is found in the colnames of the `attrition` object.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -67,10 +67,10 @@ testthat::test_that("T1.2 No error when `value_column_name` is a `character` str
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(value_column_name = "Remaining N"), NA)
+  expect_error(attrition_object %>% visR::visr(value_column_name = "Remaining N"), NA)
 })
 
-testthat::test_that("T1.3 No error when `complement_column_name` is a `character` string that is found in the colnames of the `attrition` object.", {
+test_that("T1.3 No error when `complement_column_name` is a `character` string that is found in the colnames of the `attrition` object.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -97,10 +97,10 @@ testthat::test_that("T1.3 No error when `complement_column_name` is a `character
       "Not Site 709"
     ))
 
-  testthat::expect_error(attrition_object %>% visR::visr(complement_column_name = "Complement"), NA)
+  expect_error(attrition_object %>% visR::visr(complement_column_name = "Complement"), NA)
 })
 
-testthat::test_that("T1.4 No error when `box_width` is a `numeric` value.", {
+test_that("T1.4 No error when `box_width` is a `numeric` value.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -118,10 +118,10 @@ testthat::test_that("T1.4 No error when `box_width` is a `numeric` value.", {
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(box_width = 500), NA)
+  expect_error(attrition_object %>% visR::visr(box_width = 500), NA)
 })
 
-testthat::test_that("T1.5 No error when `font_size` is a `numeric` value.", {
+test_that("T1.5 No error when `font_size` is a `numeric` value.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -139,10 +139,10 @@ testthat::test_that("T1.5 No error when `font_size` is a `numeric` value.", {
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(font_size = 13), NA)
+  expect_error(attrition_object %>% visR::visr(font_size = 13), NA)
 })
 
-testthat::test_that("T1.6 No error when `fill` is a `character` string that is a valid colour.", {
+test_that("T1.6 No error when `fill` is a `character` string that is a valid colour.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -160,10 +160,10 @@ testthat::test_that("T1.6 No error when `fill` is a `character` string that is a
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(fill = "grey"), NA)
+  expect_error(attrition_object %>% visR::visr(fill = "grey"), NA)
 })
 
-testthat::test_that("T1.7 No error when `border` is a `character` string that is a valid colour.", {
+test_that("T1.7 No error when `border` is a `character` string that is a valid colour.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -181,10 +181,10 @@ testthat::test_that("T1.7 No error when `border` is a `character` string that is
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(border = "grey"), NA)
+  expect_error(attrition_object %>% visR::visr(border = "grey"), NA)
 })
 
-testthat::test_that("T1.8 An error when `description_column_name` is a `character` string but is not found in the colnames of the `attrition` object.", {
+test_that("T1.8 An error when `description_column_name` is a `character` string but is not found in the colnames of the `attrition` object.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -202,10 +202,10 @@ testthat::test_that("T1.8 An error when `description_column_name` is a `characte
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(description_column_name = "visR"))
+  expect_error(attrition_object %>% visR::visr(description_column_name = "visR"))
 })
 
-testthat::test_that("T1.9 An error when `description_column_name` is not `character` string.", {
+test_that("T1.9 An error when `description_column_name` is not `character` string.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -225,15 +225,15 @@ testthat::test_that("T1.9 An error when `description_column_name` is not `charac
 
 
 
-  testthat::expect_error(attrition_object %>% visR::visr(description_column_name = 1))
-  testthat::expect_error(attrition_object %>% visR::visr(description_column_name = NA))
-  testthat::expect_error(attrition_object %>% visR::visr(description_column_name = NULL))
-  testthat::expect_error(attrition_object %>% visR::visr(description_column_name = TRUE))
-  testthat::expect_error(attrition_object %>% visR::visr(description_column_name = list()))
-  testthat::expect_error(attrition_object %>% visR::visr(description_column_name = stats::lm(AGE ~ TRTDUR, adtte) %>% visR::visr()))
+  expect_error(attrition_object %>% visR::visr(description_column_name = 1))
+  expect_error(attrition_object %>% visR::visr(description_column_name = NA))
+  expect_error(attrition_object %>% visR::visr(description_column_name = NULL))
+  expect_error(attrition_object %>% visR::visr(description_column_name = TRUE))
+  expect_error(attrition_object %>% visR::visr(description_column_name = list()))
+  expect_error(attrition_object %>% visR::visr(description_column_name = stats::lm(AGE ~ TRTDUR, adtte) %>% visR::visr()))
 })
 
-testthat::test_that("T1.10 An error when `value_column_name` is a `character` string but is not found in the colnames of the `attrition` object.", {
+test_that("T1.10 An error when `value_column_name` is a `character` string but is not found in the colnames of the `attrition` object.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -251,10 +251,10 @@ testthat::test_that("T1.10 An error when `value_column_name` is a `character` st
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(value_column_name = "visR"))
+  expect_error(attrition_object %>% visR::visr(value_column_name = "visR"))
 })
 
-testthat::test_that("T1.11 An error when `value_column_name` is not `character` string.", {
+test_that("T1.11 An error when `value_column_name` is not `character` string.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -272,15 +272,15 @@ testthat::test_that("T1.11 An error when `value_column_name` is not `character` 
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(value_column_name = 1))
-  testthat::expect_error(attrition_object %>% visR::visr(value_column_name = NA))
-  testthat::expect_error(attrition_object %>% visR::visr(value_column_name = NULL))
-  testthat::expect_error(attrition_object %>% visR::visr(value_column_name = TRUE))
-  testthat::expect_error(attrition_object %>% visR::visr(value_column_name = list()))
-  testthat::expect_error(attrition_object %>% visR::visr(value_column_name = stats::lm(AGE ~ TRTDUR, adtte) %>% visR::visr()))
+  expect_error(attrition_object %>% visR::visr(value_column_name = 1))
+  expect_error(attrition_object %>% visR::visr(value_column_name = NA))
+  expect_error(attrition_object %>% visR::visr(value_column_name = NULL))
+  expect_error(attrition_object %>% visR::visr(value_column_name = TRUE))
+  expect_error(attrition_object %>% visR::visr(value_column_name = list()))
+  expect_error(attrition_object %>% visR::visr(value_column_name = stats::lm(AGE ~ TRTDUR, adtte) %>% visR::visr()))
 })
 
-testthat::test_that("T1.12 An error when `complement_column_name` is a `character` string but is not found in the colnames of the `attrition` object.", {
+test_that("T1.12 An error when `complement_column_name` is a `character` string but is not found in the colnames of the `attrition` object.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -298,10 +298,10 @@ testthat::test_that("T1.12 An error when `complement_column_name` is a `characte
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(complement_column_name = "visR"))
+  expect_error(attrition_object %>% visR::visr(complement_column_name = "visR"))
 })
 
-testthat::test_that("T1.13 An error when `complement_column_name` is not `character` string.", {
+test_that("T1.13 An error when `complement_column_name` is not `character` string.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -319,15 +319,15 @@ testthat::test_that("T1.13 An error when `complement_column_name` is not `charac
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_error(attrition_object %>% visR::visr(complement_column_name = 1))
-  testthat::expect_error(attrition_object %>% visR::visr(complement_column_name = NA))
-  testthat::expect_error(attrition_object %>% visR::visr(complement_column_name = NULL))
-  testthat::expect_error(attrition_object %>% visR::visr(complement_column_name = TRUE))
-  testthat::expect_error(attrition_object %>% visR::visr(complement_column_name = list()))
-  testthat::expect_error(attrition_object %>% visR::visr(complement_column_name = stats::lm(AGE ~ TRTDUR, adtte) %>% visR::visr()))
+  expect_error(attrition_object %>% visR::visr(complement_column_name = 1))
+  expect_error(attrition_object %>% visR::visr(complement_column_name = NA))
+  expect_error(attrition_object %>% visR::visr(complement_column_name = NULL))
+  expect_error(attrition_object %>% visR::visr(complement_column_name = TRUE))
+  expect_error(attrition_object %>% visR::visr(complement_column_name = list()))
+  expect_error(attrition_object %>% visR::visr(complement_column_name = stats::lm(AGE ~ TRTDUR, adtte) %>% visR::visr()))
 })
 
-testthat::test_that("T1.14 A warning when `box_width` is not a `numeric` value.", {
+test_that("T1.14 A warning when `box_width` is not a `numeric` value.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -345,14 +345,14 @@ testthat::test_that("T1.14 A warning when `box_width` is not a `numeric` value."
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_warning(attrition_object %>% visR::visr(box_width = "visR"))
-  testthat::expect_warning(attrition_object %>% visR::visr(box_width = NA))
-  testthat::expect_warning(attrition_object %>% visR::visr(box_width = NULL))
-  testthat::expect_warning(attrition_object %>% visR::visr(box_width = TRUE))
-  testthat::expect_warning(attrition_object %>% visR::visr(box_width = list()))
+  expect_warning(attrition_object %>% visR::visr(box_width = "visR"))
+  expect_warning(attrition_object %>% visR::visr(box_width = NA))
+  expect_warning(attrition_object %>% visR::visr(box_width = NULL))
+  expect_warning(attrition_object %>% visR::visr(box_width = TRUE))
+  expect_warning(attrition_object %>% visR::visr(box_width = list()))
 })
 
-testthat::test_that("T1.15 A warning when `font_size` is not a `numeric` value.", {
+test_that("T1.15 A warning when `font_size` is not a `numeric` value.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -370,14 +370,14 @@ testthat::test_that("T1.15 A warning when `font_size` is not a `numeric` value."
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_warning(attrition_object %>% visR::visr(font_size = "visR"))
-  testthat::expect_warning(attrition_object %>% visR::visr(font_size = NA))
-  testthat::expect_warning(attrition_object %>% visR::visr(font_size = NULL))
-  testthat::expect_warning(attrition_object %>% visR::visr(font_size = TRUE))
-  testthat::expect_warning(attrition_object %>% visR::visr(font_size = list()))
+  expect_warning(attrition_object %>% visR::visr(font_size = "visR"))
+  expect_warning(attrition_object %>% visR::visr(font_size = NA))
+  expect_warning(attrition_object %>% visR::visr(font_size = NULL))
+  expect_warning(attrition_object %>% visR::visr(font_size = TRUE))
+  expect_warning(attrition_object %>% visR::visr(font_size = list()))
 })
 
-testthat::test_that("T1.16 An error when `fill` is a `character` string but not a valid colour.", {
+test_that("T1.16 An error when `fill` is a `character` string but not a valid colour.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -405,10 +405,10 @@ testthat::test_that("T1.16 An error when `fill` is a `character` string but not 
     }
   )
 
-  testthat::expect_false(could_generate_plot)
+  expect_false(could_generate_plot)
 })
 
-testthat::test_that("T1.17 An error when `fill` is not a `character` string.", {
+test_that("T1.17 An error when `fill` is not a `character` string.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -426,14 +426,14 @@ testthat::test_that("T1.17 An error when `fill` is not a `character` string.", {
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_warning(attrition_object %>% visR::visr(fill = 1))
-  testthat::expect_warning(attrition_object %>% visR::visr(fill = NA))
-  testthat::expect_warning(attrition_object %>% visR::visr(fill = NULL))
-  testthat::expect_warning(attrition_object %>% visR::visr(fill = TRUE))
-  testthat::expect_warning(attrition_object %>% visR::visr(fill = list()))
+  expect_warning(attrition_object %>% visR::visr(fill = 1))
+  expect_warning(attrition_object %>% visR::visr(fill = NA))
+  expect_warning(attrition_object %>% visR::visr(fill = NULL))
+  expect_warning(attrition_object %>% visR::visr(fill = TRUE))
+  expect_warning(attrition_object %>% visR::visr(fill = list()))
 })
 
-testthat::test_that("T1.18 An error when `border` is a `character` string but not a valid colour.", {
+test_that("T1.18 An error when `border` is a `character` string but not a valid colour.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -461,10 +461,10 @@ testthat::test_that("T1.18 An error when `border` is a `character` string but no
     }
   )
 
-  testthat::expect_false(could_generate_plot)
+  expect_false(could_generate_plot)
 })
 
-testthat::test_that("T1.19 An error when `border` is not a `character` string.", {
+test_that("T1.19 An error when `border` is not a `character` string.", {
   attrition_object <- adtte %>%
     visR::get_attrition(
       criteria_descriptions = c(
@@ -482,11 +482,11 @@ testthat::test_that("T1.19 An error when `border` is not a `character` string.",
       subject_column_name = "USUBJID"
     )
 
-  testthat::expect_warning(attrition_object %>% visR::visr(border = 1))
-  testthat::expect_warning(attrition_object %>% visR::visr(border = NA))
-  testthat::expect_warning(attrition_object %>% visR::visr(border = NULL))
-  testthat::expect_warning(attrition_object %>% visR::visr(border = TRUE))
-  testthat::expect_warning(attrition_object %>% visR::visr(border = list()))
+  expect_warning(attrition_object %>% visR::visr(border = 1))
+  expect_warning(attrition_object %>% visR::visr(border = NA))
+  expect_warning(attrition_object %>% visR::visr(border = NULL))
+  expect_warning(attrition_object %>% visR::visr(border = TRUE))
+  expect_warning(attrition_object %>% visR::visr(border = list()))
 })
 
 # END OF CODE -------------------------------------------------------------

--- a/tests/testthat/test-visr_survfit.R
+++ b/tests/testthat/test-visr_survfit.R
@@ -291,59 +291,59 @@ testthat::test_that("T2.20 An error when `x_units` is not `NULL` or a `character
 
   testthat::expect_error(survfit_object %>% visR::visr(x_units = 1))
   testthat::expect_error(survfit_object %>% visR::visr(x_units = NA))
-  testthat::expect_error(survfit_object %>% visR::visr(x_units = TRUE))
-  testthat::expect_error(survfit_object %>% visR::visr(x_units = list()))
-  testthat::expect_error(survfit_object %>% visR::visr(x_units = stats::lm(AGE ~ TRTDUR, adtte)))
+  expect_error(survfit_object %>% visR::visr(x_units = TRUE))
+  expect_error(survfit_object %>% visR::visr(x_units = list()))
+  expect_error(survfit_object %>% visR::visr(x_units = stats::lm(AGE ~ TRTDUR, adtte)))
 })
 
-testthat::test_that("T2.21 An error when `x_ticks` is not `NULL` or a `numeric`.", {
+test_that("T2.21 An error when `x_ticks` is not `NULL` or a `numeric`.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(x_ticks = "visR"))
-  testthat::expect_error(survfit_object %>% visR::visr(x_ticks = NA))
-  testthat::expect_error(survfit_object %>% visR::visr(x_ticks = TRUE))
-  testthat::expect_error(survfit_object %>% visR::visr(x_ticks = list()))
-  testthat::expect_error(survfit_object %>% visR::visr(x_ticks = stats::lm(AGE ~ TRTDUR, adtte)))
+  expect_error(survfit_object %>% visR::visr(x_ticks = "visR"))
+  expect_error(survfit_object %>% visR::visr(x_ticks = NA))
+  expect_error(survfit_object %>% visR::visr(x_ticks = TRUE))
+  expect_error(survfit_object %>% visR::visr(x_ticks = list()))
+  expect_error(survfit_object %>% visR::visr(x_ticks = stats::lm(AGE ~ TRTDUR, adtte)))
 })
 
-testthat::test_that("T2.22 An error when `y_ticks` is not `NULL` or a `numeric`.", {
+test_that("T2.22 An error when `y_ticks` is not `NULL` or a `numeric`.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(y_ticks = "visR"))
-  testthat::expect_error(survfit_object %>% visR::visr(y_ticks = NA))
-  testthat::expect_error(survfit_object %>% visR::visr(y_ticks = TRUE))
-  testthat::expect_error(survfit_object %>% visR::visr(y_ticks = list()))
-  testthat::expect_error(survfit_object %>% visR::visr(y_ticks = stats::lm(AGE ~ TRTDUR, adtte)))
+  expect_error(survfit_object %>% visR::visr(y_ticks = "visR"))
+  expect_error(survfit_object %>% visR::visr(y_ticks = NA))
+  expect_error(survfit_object %>% visR::visr(y_ticks = TRUE))
+  expect_error(survfit_object %>% visR::visr(y_ticks = list()))
+  expect_error(survfit_object %>% visR::visr(y_ticks = stats::lm(AGE ~ TRTDUR, adtte)))
 })
 
-testthat::test_that("T2.23 No error when a valid option is passed to `legend_position`.", {
+test_that("T2.23 No error when a valid option is passed to `legend_position`.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = "top"), NA)
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = "bottom"), NA)
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = "right"), NA)
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = "left"), NA)
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = "none"), NA)
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = c(0.5, 0.5)), NA)
+  expect_error(survfit_object %>% visR::visr(legend_position = "top"), NA)
+  expect_error(survfit_object %>% visR::visr(legend_position = "bottom"), NA)
+  expect_error(survfit_object %>% visR::visr(legend_position = "right"), NA)
+  expect_error(survfit_object %>% visR::visr(legend_position = "left"), NA)
+  expect_error(survfit_object %>% visR::visr(legend_position = "none"), NA)
+  expect_error(survfit_object %>% visR::visr(legend_position = c(0.5, 0.5)), NA)
 })
 
-testthat::test_that("T2.24 An error when the string is not amongst the valid options for `legend_position`.", {
+test_that("T2.24 An error when the string is not amongst the valid options for `legend_position`.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = "visR"))
+  expect_error(survfit_object %>% visR::visr(legend_position = "visR"))
 })
 
-testthat::test_that("T2.25 An error when an undefined option is passed to `legend_position`.", {
+test_that("T2.25 An error when an undefined option is passed to `legend_position`.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = "visR"))
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = c(0)))
-  testthat::expect_error(survfit_object %>% visR::visr(legend_position = c(0.5, 0.5, 0.5)))
+  expect_error(survfit_object %>% visR::visr(legend_position = "visR"))
+  expect_error(survfit_object %>% visR::visr(legend_position = c(0)))
+  expect_error(survfit_object %>% visR::visr(legend_position = c(0.5, 0.5, 0.5)))
 
   could_set_to_NA <- tryCatch(
     {
@@ -355,7 +355,7 @@ testthat::test_that("T2.25 An error when an undefined option is passed to `legen
     }
   )
 
-  testthat::expect_false(could_set_to_NA)
+  expect_false(could_set_to_NA)
 
   could_set_to_bool <- tryCatch(
     {
@@ -367,7 +367,7 @@ testthat::test_that("T2.25 An error when an undefined option is passed to `legen
     }
   )
 
-  testthat::expect_false(could_set_to_bool)
+  expect_false(could_set_to_bool)
 
   could_set_to_list <- tryCatch(
     {
@@ -379,78 +379,78 @@ testthat::test_that("T2.25 An error when an undefined option is passed to `legen
     }
   )
 
-  testthat::expect_false(could_set_to_list)
+  expect_false(could_set_to_list)
 })
 
 # Requirement T3 ---------------------------------------------------------------
 
-testthat::context("visr_plot - T3. The y-axis properties are correctly deducted from the provided `fun` when applying `visR::visr()` to a `survfit` object.")
+context("visr_plot - T3. The y-axis properties are correctly deducted from the provided `fun` when applying `visR::visr()` to a `survfit` object.")
 
-testthat::test_that("T3.1 No error when `y_label` is `NULL` and `fun` is one of the valid string options.", {
+test_that("T3.1 No error when `y_label` is `NULL` and `fun` is one of the valid string options.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "surv"), NA)
-  testthat::expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "log"), NA)
-  testthat::expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "event"), NA)
-  testthat::expect_warning(survfit_object %>% visR::visr(y_label = NULL, fun = "cloglog")) # No error, but data causes introduction of NAs.
-  testthat::expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "pct"), NA)
-  testthat::expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "logpct"), NA)
-  testthat::expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "cumhaz"), NA)
+  expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "surv"), NA)
+  expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "log"), NA)
+  expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "event"), NA)
+  expect_warning(survfit_object %>% visR::visr(y_label = NULL, fun = "cloglog")) # No error, but data causes introduction of NAs.
+  expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "pct"), NA)
+  expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "logpct"), NA)
+  expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "cumhaz"), NA)
 })
 
-testthat::test_that("T3.2 An error when `y_label` is `NULL`, `fun` is a string but not one of the valid options.", {
+test_that("T3.2 An error when `y_label` is `NULL`, `fun` is a string but not one of the valid options.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "visR"))
+  expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = "visR"))
 })
 
-testthat::test_that("T3.3 No error when `y_label` is a string and `fun` is a function.", {
+test_that("T3.3 No error when `y_label` is a string and `fun` is a function.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(y_label = "visR", fun = log), NA)
+  expect_error(survfit_object %>% visR::visr(y_label = "visR", fun = log), NA)
 })
 
-testthat::test_that("T3.4 An error when `y_label` is `NULL` and `fun` is a function.", {
+test_that("T3.4 An error when `y_label` is `NULL` and `fun` is a function.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = log))
+  expect_error(survfit_object %>% visR::visr(y_label = NULL, fun = log))
 })
 
-testthat::test_that("T3.5 A warning when the provided function causes undefined values, f.e. log(-log(2)).", {
+test_that("T3.5 A warning when the provided function causes undefined values, f.e. log(-log(2)).", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_warning(survfit_object %>% visR::visr(y_label = NULL, fun = "cloglog"))
+  expect_warning(survfit_object %>% visR::visr(y_label = NULL, fun = "cloglog"))
 })
 
-testthat::test_that("T3.6 An error when `fun` is neither a `character` string nor a function.", {
+test_that("T3.6 An error when `fun` is neither a `character` string nor a function.", {
   survfit_object <- adtte %>%
     visR::estimate_KM("SEX")
 
-  testthat::expect_error(survfit_object %>% visR::visr(fun = 1))
-  testthat::expect_error(survfit_object %>% visR::visr(fun = NULL))
-  testthat::expect_error(survfit_object %>% visR::visr(fun = NA))
-  testthat::expect_error(survfit_object %>% visR::visr(fun = TRUE))
-  testthat::expect_error(survfit_object %>% visR::visr(fun = list()))
+  expect_error(survfit_object %>% visR::visr(fun = 1))
+  expect_error(survfit_object %>% visR::visr(fun = NULL))
+  expect_error(survfit_object %>% visR::visr(fun = NA))
+  expect_error(survfit_object %>% visR::visr(fun = TRUE))
+  expect_error(survfit_object %>% visR::visr(fun = list()))
 })
 
-testthat::test_that("T3.7 The `fun` argument is stored in the final object as attribute `fun`.", {
+test_that("T3.7 The `fun` argument is stored in the final object as attribute `fun`.", {
   survfit_plot <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr(fun = "log")
 
-  testthat::expect_true(inherits(attr(survfit_plot, "fun"), "function"))
+  expect_true(inherits(attr(survfit_plot, "fun"), "function"))
 })
 
 # Requirement T4 ---------------------------------------------------------------
 
-testthat::context("visr_plot - T4. The legend follows the model strata label and levels.")
+context("visr_plot - T4. The legend follows the model strata label and levels.")
 
-testthat::test_that("T4.1 The legend follows the model strata levels.", {
+test_that("T4.1 The legend follows the model strata levels.", {
   dt <- adtte
   dt[["TRTA"]] <- factor(dt[["TRTA"]], levels = c("Placebo", "Xanomeline Low Dose", "Xanomeline High Dose"))
 
@@ -460,15 +460,15 @@ testthat::test_that("T4.1 The legend follows the model strata levels.", {
   leg <- ggplot2::ggplot_build(survfit_plot)
   labs <- leg$plot$scales$scales[[4]]$get_labels()
 
-  testthat::expect_equal(paste0(levels(dt$TRTA)), labs)
+  expect_equal(paste0(levels(dt$TRTA)), labs)
 })
 
-testthat::test_that("T4.2 The color legend title represents the strata label.", {
+test_that("T4.2 The color legend title represents the strata label.", {
   survfit_plot <- adtte %>%
     visR::estimate_KM(strata = "TRTA") %>%
     visR::visr()
 
-  testthat::expect_equal(
+  expect_equal(
     survfit_plot$labels$colour,
     "Actual Treatment"
   )
@@ -477,7 +477,7 @@ testthat::test_that("T4.2 The color legend title represents the strata label.", 
     visR::estimate_KM(strata = c("TRTA", "SEX")) %>%
     visR::visr()
 
-  testthat::expect_equal(
+  expect_equal(
     survfit_plot$labels$colour,
     "Actual Treatment, Sex"
   )
@@ -486,7 +486,7 @@ testthat::test_that("T4.2 The color legend title represents the strata label.", 
     visR::estimate_KM() %>%
     visR::visr()
 
-  testthat::expect_equal(
+  expect_equal(
     survfit_plot$labels$colour,
     ""
   )
@@ -494,29 +494,29 @@ testthat::test_that("T4.2 The color legend title represents the strata label.", 
 
 # Requirement T5 ---------------------------------------------------------------
 
-testthat::context("visr_plot - T5. The final object is a ggplot of class `ggsurvfit`.")
+context("visr_plot - T5. The final object is a ggplot of class `ggsurvfit`.")
 
-testthat::test_that("T5.1 The final object is a ggplot of class `ggplot`.", {
+test_that("T5.1 The final object is a ggplot of class `ggplot`.", {
   survfit_plot <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr(fun = "log")
 
-  testthat::expect_true(inherits(survfit_plot, "ggplot"))
+  expect_true(inherits(survfit_plot, "ggplot"))
 })
 
-testthat::test_that("T5.2 The final object is a ggplot of class `ggsurvfit`.", {
+test_that("T5.2 The final object is a ggplot of class `ggsurvfit`.", {
   survfit_plot <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr(fun = "log")
 
-  testthat::expect_true(inherits(survfit_plot, "ggsurvfit"))
+  expect_true(inherits(survfit_plot, "ggsurvfit"))
 })
 
 # Requirement T6 ---------------------------------------------------------------
 
-testthat::context("visr_plot - T6. The final object does not exclude parts of KM estimate.")
+context("visr_plot - T6. The final object does not exclude parts of KM estimate.")
 
-testthat::test_that("T6.1 The final object zooms and does not exclude trialing pieces of lines.", {
+test_that("T6.1 The final object zooms and does not exclude trialing pieces of lines.", {
   plot.zoom <-
     visR::estimate_KM(
       data = survival::lung %>% dplyr::mutate(time = ifelse(time > 1000, 2001, time)),

--- a/tests/testthat/test-watchdog_CRAN.R
+++ b/tests/testthat/test-watchdog_CRAN.R
@@ -12,9 +12,9 @@
 
 # Requirement T1 ---------------------------------------------------------------
 
-testthat::context("CRAN_watchdog - T1. Our codebase doesn't violate CRAN style-guidelines.")
+context("CRAN_watchdog - T1. Our codebase doesn't violate CRAN style-guidelines.")
 
-testthat::test_that("T1.1 TRUE/FALSE are used instead of T/F.", {
+test_that("T1.1 TRUE/FALSE are used instead of T/F.", {
   test_files <- .get_visR_files(
     functions = TRUE,
     tests = TRUE,
@@ -48,10 +48,10 @@ testthat::test_that("T1.1 TRUE/FALSE are used instead of T/F.", {
     cat(paste0(CRAN_incompabilities, collapse = ";"))
   }
 
-  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  expect_true(base::nrow(CRAN_incompabilities) == 0)
 })
 
-testthat::test_that("T1.2 Each function documentation contains a \\value{} tag.", {
+test_that("T1.2 Each function documentation contains a \\value{} tag.", {
   test_files <- .get_visR_files(documentation = TRUE)
 
   # List of files in which we don't expect a return value.
@@ -90,10 +90,10 @@ testthat::test_that("T1.2 Each function documentation contains a \\value{} tag."
     print(CRAN_incompabilities)
   }
 
-  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  expect_true(base::nrow(CRAN_incompabilities) == 0)
 })
 
-testthat::test_that("T1.3 The existence of packages is not checked through 'installed.packages()'.", {
+test_that("T1.3 The existence of packages is not checked through 'installed.packages()'.", {
 
   # installed.packages might be slow on CRAN servers
 
@@ -123,10 +123,10 @@ testthat::test_that("T1.3 The existence of packages is not checked through 'inst
     print(CRAN_incompabilities)
   }
 
-  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  expect_true(base::nrow(CRAN_incompabilities) == 0)
 })
 
-testthat::test_that("T1.4 No \\dontrun{} tags unless the code actually takes a long time.", {
+test_that("T1.4 No \\dontrun{} tags unless the code actually takes a long time.", {
   test_files <- .get_visR_files(documentation = TRUE)
 
   # List of files in which we don't expect a return value.
@@ -158,10 +158,10 @@ testthat::test_that("T1.4 No \\dontrun{} tags unless the code actually takes a l
     print(CRAN_incompabilities)
   }
 
-  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  expect_true(base::nrow(CRAN_incompabilities) == 0)
 })
 
-testthat::test_that("T1.5 The use of 'options()' is immediately preemptively reverted.", {
+test_that("T1.5 The use of 'options()' is immediately preemptively reverted.", {
   test_files <- .get_visR_files(
     functions = TRUE,
     tests = TRUE,
@@ -191,5 +191,5 @@ testthat::test_that("T1.5 The use of 'options()' is immediately preemptively rev
     print(CRAN_incompabilities)
   }
 
-  testthat::expect_true(base::nrow(CRAN_incompabilities) == 0)
+  expect_true(base::nrow(CRAN_incompabilities) == 0)
 })

--- a/tests/testthat/test-watchdog_testfiles.R
+++ b/tests/testthat/test-watchdog_testfiles.R
@@ -10,11 +10,11 @@
 
 context("validate_watchdog - T1. Details on last change for test files are recorded.")
 # skip on GH Actions and CRAN
-testthat::skip_if(isTRUE(as.logical(Sys.getenv("CI"))))
-testthat::skip_on_cran()
-testthat::skip_on_os("windows")
+skip_if(isTRUE(as.logical(Sys.getenv("CI"))))
+skip_on_cran()
+skip_on_os("windows")
 
-testthat::test_that("T1.1 executed.", {
+test_that("T1.1 executed.", {
   test_files <- .get_visR_files(tests = TRUE)
 
   test_files <- test_files[!(grepl("watchdog", test_files))]
@@ -64,7 +64,7 @@ testthat::test_that("T1.1 executed.", {
       new_header,
       "# Requirement T1 ",
       paste0(rep("-", 58), collapse = ""),
-      "\n\ntestthat::context"
+      "\n\ncontext"
     )
 
     file_content <- gsub(
@@ -96,5 +96,5 @@ testthat::test_that("T1.1 executed.", {
     cat(file_content, file = x["full_path"])
   })
 
-  testthat::expect_true(TRUE)
+  expect_true(TRUE)
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
As previously discussed, removing the `testthat::` prefix in the unit testing files. Without the prefix, the RStudio IDE recognizes the unit testing files as unit tests and displays additional tools for testing.

To run the unit test, the following options are available:
1. Click the "Run Tests" button in the IDE
2. Use `devtools::load_all()` (also has a button in the IDE and a built-in keyboard shortcut), then run the tests.
3. Run all the tests with `devtools::run_tests()` (also has an IDE button)

**Which files are involved in this pull request and what changes were made?**
All unit testing files `test-***.R`

**If there is an GitHub issue associated with this pull request, please provide link.**
closes #407 
closes #406

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function should be included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Before you run, begin a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading indicating the latest version. If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [ ] Run `devtools::build_readme()` to build the `README.md` file.
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
