### PR TITLE
Deprecating `visr.survfit()` and `visr.tidycuminc()`

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,6 +1,0 @@
-# this sets the dev folder in the .libPath
-# if user has not set up dev mode, nothing will happen
-tryCatch(
-  devtools::dev_mode(on = TRUE),
-  error = function(e) invisible()
-)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: visR
 Title: Clinical Graphs and Tables Adhering to Graphical Principles
-Version: 0.3.1
+Version: 0.4.0
 Authors@R: c(
     person("Mark", "Baillie", , "bailliem@gmail.com", role = c("aut", "cre", "cph")),
     person("Diego", "Saldana", , "diego.saldana@roche.com", role = "aut"),
@@ -37,6 +37,7 @@ Imports:
     gridExtra,
     gtable,
     kableExtra,
+    lifecycle,
     rlang (>= 1.0.0),
     survival (>= 3.4-0),
     tidyr (>= 1.0.0)
@@ -48,7 +49,6 @@ Suggests:
     gt (>= 0.3.0),
     knitr,
     learnr,
-    lifecycle,
     rmarkdown,
     rsconnect,
     shiny,
@@ -64,4 +64,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# visR 0.4.0
+
+* Functions `estimate_KM()` and `visr.survfit()` have been deprecated in favor of `ggsurvfit::ggsurvfit()`.
+
 # visR 0.3.1
 
 * We now zoom in on a figure (e.g. Kaplan-Meier figure) with `ggplot2::coord_cartesian()` instead of using `scale_x_continuous(limits=)` and `scale_y_continuous(limits=)`. The latter first removes data outside the limits, then constructs the line. Zooming constructs the full line, then zooms into the limits. This is useful because the risktable often reports estimates near the end of a KM figure, but the line is cutoff and not shown at the last time point. (#402)

--- a/R/estimate_KM.R
+++ b/R/estimate_KM.R
@@ -1,6 +1,8 @@
 #' @title Wrapper for Kaplan-Meier Time-to-Event analysis
 #'
 #' @description
+#' `r lifecycle::badge("deprecated")`
+#'
 #' This function is a wrapper around `survival::survfit.formula()`
 #'    to perform a Kaplan-Meier analysis, assuming right-censored data.
 #'    The result is an object of class \code{survfit} which can be used in
@@ -88,6 +90,11 @@ estimate_KM <- function(data = NULL,
                         AVAL = "AVAL",
                         formula = NULL,
                         ...) {
+  lifecycle::deprecate_warn(
+    when = "0.4.0",
+    what = "visR::estimate_KM()",
+    details = "Please use `ggsurvfit::ggsurvfit()` instead."
+  )
 
   # Capture input to validate user input for data argument ---------------------
 

--- a/R/visr.R
+++ b/R/visr.R
@@ -3,9 +3,12 @@
 #' @description S3 method for creating plots directly from objects using `ggplot2`,
 #'   similar to the base R `plot()` function.
 #'
+#' `r lifecycle::badge("deprecated")` Methods `visr.survfit()` and `visr.tidycuminc()` have been deprecated
+#' in favor of `ggsurvfit::ggsurvfit()` and `ggsurvfit::ggcuminc()`, respectively.
+#'
 #' @seealso \code{\link[ggplot2]{ggplot}}
 #'
-#' @param x Object of class `survfit`, `attritiontable`, or `tidycuminc`
+#' @param x Object of class `attritiontable`
 #' @param x_label \code{character} Label for the x-axis. When not specified,
 #'   the function will look for `"PARAM"` or `"PARAMCD"` information in the original data set (CDISC standards).
 #'   If no `"PARAM"`/`"PARAMCD"` information is available, the default x-axis label is `"Time"`.
@@ -101,6 +104,11 @@ visr.survfit <- function(x = NULL,
                          fun = "surv",
                          legend_position = "right",
                          ...) {
+  lifecycle::deprecate_warn(
+    when = "0.4.0",
+    what = "visR::visr.survfit()",
+    details = "Please use `ggsurvfit::ggsurvfit()` instead."
+  )
 
   # Minimal input validation  ----------------------------------------------------
 
@@ -310,7 +318,7 @@ visr.survfit <- function(x = NULL,
 
 #' @description
 #' `r lifecycle::badge("questioning")`
-#' S3 function to draw a Consort flow diagram chart.
+#' `visr.attrition()` function to draw a Consort flow diagram chart is currently being questioned.
 #'
 #' @examples
 #'
@@ -516,6 +524,12 @@ visr.tidycuminc <- function(x = NULL,
                             y_ticks = pretty(c(0, 1), 5),
                             legend_position = "right",
                             ...) {
+  lifecycle::deprecate_warn(
+    when = "0.4.0",
+    what = "visR::visr.tidycuminc()",
+    details = "Please use `ggsurvfit::ggcuminc()` instead."
+  )
+
   # check for installation of tidycmprsk package
   rlang::check_installed("tidycmprsk", version = "0.1.1")
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -30,7 +30,7 @@ riskmetric_score <- "visR" %>%
 
 <!-- badges: start -->
 
-[![Lifecycle: experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+[![Lifecycle: questioning](https://img.shields.io/badge/lifecycle-questioning-blue)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![Codecov test coverage](https://codecov.io/gh/openpharma/visR/branch/develop/graph/badge.svg)](https://app.codecov.io/gh/openpharma/visR?branch=main)
 [![R-CMD-check](https://github.com/openpharma/visR/workflows/R-CMD-check/badge.svg)](https://github.com/openpharma/visR/actions)
 [![CRAN status](https://www.r-pkg.org/badges/version/visR)](https://CRAN.R-project.org/package=visR)
@@ -66,29 +66,6 @@ Install the *development* version from [GitHub](https://github.com/openpharma/vi
 ``` r
 # defaults to main branch
 devtools::install_github("openpharma/visR") 
-```
-
-## Examples
-
-#### Visualization
-
-This is a basic example to demonstrate how the API can be used to add layers to a visualization. This example demonstrates a time-to-event analysis. The example calculates and then plots stratified Kaplan-Meier by treatment. It is possible to add uncertainty intervals, censoring information, and a risk table using additional functions.
-
-```{r example, warning=FALSE, message = FALSE}
-library(visR)
-library(ggplot2)
-
-theme_set(theme_minimal())
-
-adtte %>%
-  estimate_KM(strata = "TRTP", conf.int = 0.90) %>%
-  visr(legend_position = "right", x_unit = "Days") %>%
-  add_CI(style = "ribbon") %>%
-  add_CNSR(shape = 3, size = 1) %>%
-  add_risktable(
-    statlist = c("n.risk", "n.event", "n.censor"),
-    label = c("At risk", "Event", "Censor")
-  )
 ```
 
 ## Cite visR

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@
 <!-- badges: start -->
 
 [![Lifecycle:
-experimental](https://img.shields.io/badge/lifecycle-experimental-orange.svg)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
+questioning](https://img.shields.io/badge/lifecycle-questioning-blue)](https://lifecycle.r-lib.org/articles/stages.html#experimental)
 [![Codecov test
 coverage](https://codecov.io/gh/openpharma/visR/branch/develop/graph/badge.svg)](https://app.codecov.io/gh/openpharma/visR?branch=main)
 [![R-CMD-check](https://github.com/openpharma/visR/workflows/R-CMD-check/badge.svg)](https://github.com/openpharma/visR/actions)
 [![CRAN
 status](https://www.r-pkg.org/badges/version/visR)](https://CRAN.R-project.org/package=visR)
-<a href=https://github.com/pharmaR/riskmetric><img src=https://img.shields.io/badge/riskmetric--1.5-green></img></a>
+<a href=https://github.com/pharmaR/riskmetric><img src=https://img.shields.io/badge/riskmetric-0.5-green></img></a>
 <!-- badges: end -->
 
 The goal of visR is to enable fit-for-purpose, reusable clinical and
@@ -29,10 +29,10 @@ By using a common package for visualising data analysis results in the
 clinical development process, we want to have a **positive influence**
 on
 
--   **choice of visualisation** by making it easy explore different
-    visualisation and to use impactful visualisations fit-for-purpose
--   effective visual communication by making it easy to **implement best
-    practices**
+- **choice of visualisation** by making it easy explore different
+  visualisation and to use impactful visualisations fit-for-purpose
+- effective visual communication by making it easy to **implement best
+  practices**
 
 We are not judging on what visualisation you chose for your research
 question, but want to facilitate and support good practice.
@@ -55,35 +55,6 @@ Install the *development* version from
 # defaults to main branch
 devtools::install_github("openpharma/visR") 
 ```
-
-## Examples
-
-#### Visualization
-
-This is a basic example to demonstrate how the API can be used to add
-layers to a visualization. This example demonstrates a time-to-event
-analysis. The example calculates and then plots stratified Kaplan-Meier
-by treatment. It is possible to add uncertainty intervals, censoring
-information, and a risk table using additional functions.
-
-``` r
-library(visR)
-library(ggplot2)
-
-theme_set(theme_minimal())
-
-adtte %>%
-  estimate_KM(strata = "TRTP", conf.int = 0.90) %>%
-  visr(legend_position = "right", x_unit = "Days") %>%
-  add_CI(style = "ribbon") %>%
-  add_CNSR(shape = 3, size = 1) %>%
-  add_risktable(
-    statlist = c("n.risk", "n.event", "n.censor"),
-    label = c("At risk", "Event", "Censor")
-  )
-```
-
-<img src="man/figures/README-example-1.png" width="100%" />
 
 ## Cite visR
 
@@ -122,6 +93,7 @@ agree to abide by its terms. Thank you to all contributors:
 [@rebecca-albrecht](https://github.com/rebecca-albrecht),
 [@SHAESEN2](https://github.com/SHAESEN2),
 [@thanos-siadimas](https://github.com/thanos-siadimas),
+[@therneau](https://github.com/therneau),
 [@thomas-neitmann](https://github.com/thomas-neitmann),
 [@timtreis](https://github.com/timtreis),
 [@yonicd](https://github.com/yonicd)

--- a/man/estimate_KM.Rd
+++ b/man/estimate_KM.Rd
@@ -38,6 +38,8 @@ Use \code{?survival::survfit.formula} and \code{?survival::survfitCI} for more i
 survfit object ready for downstream processing in estimation or visualization functions and methods.
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+
 This function is a wrapper around \code{survival::survfit.formula()}
 to perform a Kaplan-Meier analysis, assuming right-censored data.
 The result is an object of class \code{survfit} which can be used in

--- a/man/stat_stepribbon.Rd
+++ b/man/stat_stepribbon.Rd
@@ -24,10 +24,10 @@ stat_stepribbon(
 StatStepribbon
 }
 \arguments{
-\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}} or
-\code{\link[ggplot2:aes_]{aes_()}}. If specified and \code{inherit.aes = TRUE} (the
-default), it is combined with the default mapping at the top level of the
-plot. You must supply \code{mapping} if there is no plot mapping.}
+\item{mapping}{Set of aesthetic mappings created by \code{\link[ggplot2:aes]{aes()}}. If specified and
+\code{inherit.aes = TRUE} (the default), it is combined with the default mapping
+at the top level of the plot. You must supply \code{mapping} if there is no plot
+mapping.}
 
 \item{data}{The data to be displayed in this layer. There are three
 options:
@@ -46,8 +46,10 @@ from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
 \item{geom}{which geom to use; defaults to "\code{ribbon}"}
 
-\item{position}{Position adjustment, either as a string, or the result of
-a call to a position adjustment function.}
+\item{position}{Position adjustment, either as a string naming the adjustment
+(e.g. \code{"jitter"} to use \code{position_jitter}), or the result of a call to a
+position adjustment function. Use the latter if you need to change the
+settings of the adjustment.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}

--- a/man/visr.Rd
+++ b/man/visr.Rd
@@ -48,7 +48,7 @@ visr(x, ...)
 )
 }
 \arguments{
-\item{x}{Object of class \code{survfit}, \code{attritiontable}, or \code{tidycuminc}}
+\item{x}{Object of class \code{attritiontable}}
 
 \item{...}{other arguments passed on to the method}
 
@@ -112,8 +112,11 @@ Object of class \code{ggplot} and \code{ggsurvplot} for \code{survfit} objects.
 S3 method for creating plots directly from objects using \code{ggplot2},
 similar to the base R \code{plot()} function.
 
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} Methods \code{visr.survfit()} and \code{visr.tidycuminc()} have been deprecated
+in favor of \code{ggsurvfit::ggsurvfit()} and \code{ggsurvfit::ggcuminc()}, respectively.
+
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#questioning}{\figure{lifecycle-questioning.svg}{options: alt='[Questioning]'}}}{\strong{[Questioning]}}
-S3 function to draw a Consort flow diagram chart.
+\code{visr.attrition()} function to draw a Consort flow diagram chart is currently being questioned.
 }
 \examples{
 


### PR DESCRIPTION
- Deprecating `visr.survfit()` and `visr.tidycuminc()`
- Version number has been bumped to `v0.4.0` and should be ready for release @bailliem . Although, you should go through the `usethis::use_release_issue()` checklist before submitting to CRAN.