### PR TITLE
Compatibility with incoming version of ggplot2

### DIFF
--- a/R/add_highlight.R
+++ b/R/add_highlight.R
@@ -86,7 +86,8 @@ add_highlight.ggsurvfit <- function(gg = NULL,
   gg_gb <- ggplot2::ggplot_build(gg)
 
   if ("get_guide_data" %in% getNamespaceExports("ggplot2")) {
-    strata_labels <- ggplot2::get_guide_data(gg_gb, "colour")$.label
+    get_guide_data <- get("get_guide_data", asNamespace("ggplot2"))
+    strata_labels  <- get_guide_data(gg_gb, "colour")$.label
   } else {
     gg_gtable <- ggplot2::ggplot_gtable(gg_gb)
     gg_guidebox_id <- base::which(base::sapply(

--- a/R/add_highlight.R
+++ b/R/add_highlight.R
@@ -84,26 +84,31 @@ add_highlight.ggsurvfit <- function(gg = NULL,
 
   # Extract names of strata objects
   gg_gb <- ggplot2::ggplot_build(gg)
-  gg_gtable <- ggplot2::ggplot_gtable(gg_gb)
-  gg_guidebox_id <- base::which(base::sapply(
-    gg_gtable$grobs,
-    function(x) x$name
-  ) == "guide-box")
-  gg_table_grob <- gg_gtable$grobs[[gg_guidebox_id]]$grobs[[1]]
 
-  # Get IDs of elements containing strata labels
-  strata_label_ids <- base::grep("label", gg_table_grob$layout$name)
+  if ("get_guide_data" %in% getNamespaceExports("ggplot2")) {
+    strata_labels <- ggplot2::get_guide_data(gg_gb, "colour")$.label
+  } else {
+    gg_gtable <- ggplot2::ggplot_gtable(gg_gb)
+    gg_guidebox_id <- base::which(base::sapply(
+      gg_gtable$grobs,
+      function(x) x$name
+    ) == "guide-box")
+    gg_table_grob <- gg_gtable$grobs[[gg_guidebox_id]]$grobs[[1]]
 
-  extract_strata_name_by_id <- function(gg_table_grob, id) {
-    label <- gg_table_grob$grobs[[id]]$children[[1]]$children[[1]]$label
+    # Get IDs of elements containing strata labels
+    strata_label_ids <- base::grep("label", gg_table_grob$layout$name)
 
-    return(label)
+    extract_strata_name_by_id <- function(gg_table_grob, id) {
+      label <- gg_table_grob$grobs[[id]]$children[[1]]$children[[1]]$label
+
+      return(label)
+    }
+
+    strata_labels <- base::sapply(strata_label_ids,
+                                  extract_strata_name_by_id,
+                                  gg_table_grob = gg_table_grob
+    )
   }
-
-  strata_labels <- base::sapply(strata_label_ids,
-    extract_strata_name_by_id,
-    gg_table_grob = gg_table_grob
-  )
 
   base::sapply(c(strata), function(s) {
     if (!(s %in% strata_labels)) {

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -207,6 +207,11 @@ get_legend_title <- function(gg) {
   ggb <- ggplot2::ggplot_build(gg)
   ggt <- ggplot2::ggplot_gtable(ggb)
 
+  if (inherits(ggb$plot$guides, "Guides")) {
+    params <- ggb$plot$guides$get_params(1)
+    return(params$title)
+  }
+
   legend_grob_id <- which(sapply(ggt$grobs, function(x) x$name) == "guide-box")
   legend_grob <- ggt$grobs[[legend_grob_id]]
 

--- a/tests/testthat/test-utils_visR.R
+++ b/tests/testthat/test-utils_visR.R
@@ -92,6 +92,10 @@ testthat::test_that("T1.3 An error when a list containing non-`ggplot` objects i
 testthat::context("utils_visr - T2. `align_plots()` aligns multiple `ggplot` objects, taking the legend into account.")
 
 testthat::test_that("T2.1 Columns are added to the grob-converted plot.", {
+  # From ggplot2 3.5.0 onwards ggplots have stable gtable dimensions with
+  # regards to legend placement
+  skip_if(utils::packageVersion("ggplot2") >= "3.5.0")
+
   gg_sex <- adtte %>%
     visR::estimate_KM("SEX") %>%
     visR::visr()


### PR DESCRIPTION
Hello there,

We have been preparing a new release of ggplot2 and during a reverse dependency check, it became apparent that the prospective ggplot2 3.5.0 would break bayesplot.

**What changes are proposed in this pull request?**

This PR updates functionality in visR that suffers under the new version of ggplot2. To briefly summarise, visR makes several assumptions about the internal structure of the gtable structures that ggplot2 produces. Some of these structures have changes, most noteably guide boxes.

To test the code changes with the release candidate, you can install it with the code below:

```r
remotes::install_github("tidyverse/ggplot2", ref = remotes::github_pull("5592"))
```

The release of ggplot2 3.5.0 is scheduled for the 12th of February. The progress of the release can be tracked in https://github.com/tidyverse/ggplot2/issues/5588. We hope that this PR might help visR get out a fix if necessary.

**Which files are involved in this pull request and what changes were made?**

You can see this in the 'Files changed' tab, but for compleness:
* R/add_highlight.R
* tests/testthat/helper.R
* tests/testthat/test-utils-visR.R

**Did you include unit tests for the proposed change/bug fix (https://testthat.r-lib.org/)?**

No. The changes I made are necessarily covered by unit tests otherwise they wouldn't have been on my radar to fix them.

**If there is an GitHub issue associated with this pull request, please provide link.**

No.

--------------------------------------------------------------------------------

Checklist for PR reviewer

- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function should be included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Before you run, begin a fresh R session without any packages loaded. 
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation
- [ ] Has `NEWS.md` been updated with the changes from this pull request under the heading indicating the latest version. If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Has the version number been incremented using `usethis::use_version(which = "dev")` 
- [ ] Run `devtools::build_readme()` to build the `README.md` file.
- [ ] Approve Pull Request
- [ ] Merge the PR. Please use "Squash and merge".
